### PR TITLE
fix: correct selene config and go cache path in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.21"
+          cache-dependency-path: go/go.sum
       - name: Install ripgrep
         run: sudo apt-get install -y ripgrep
       - name: Run Go tests

--- a/selene.toml
+++ b/selene.toml
@@ -1,2 +1,1 @@
-[config]
-std = "lua51+vim"
+std = "vim"

--- a/vim.yml
+++ b/vim.yml
@@ -1,4 +1,5 @@
 ---
+base: lua51
 globals:
   vim:
     any: true


### PR DESCRIPTION
## Summary
- Fix selene lint failure: `std` was nested under `[config]` instead of top-level in `selene.toml`, causing `vim` global to be unrecognized
- Add `base: lua51` to `vim.yml` so the custom std inherits lua51 builtins
- Fix go-test cache warning by setting `cache-dependency-path: go/go.sum` in `actions/setup-go@v5`

## Test plan
- [ ] Verify CI passes on this PR (selene + go-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)