### PR TITLE
feat: frontmatter due inheritance, SortLast, and docs sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 go/task_bin
+go/taskbuffer
 doc/tags
 .worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,21 +28,29 @@ Requires `rg` (ripgrep) on PATH.
 - **`scan.go`** — Runs `rg --json` against notes dir, returns `[]RawMatch`
 - **`parse.go`** — Parses raw matched lines into `Task` structs
 - **`format.go`** — Formats tasks into taskfile display (bucketed by date interval)
+- **`horizon.go`** — Horizon specs, resolution, and default horizons
+- **`timeformat.go`** — Strftime-to-Go format and regex conversion
 - **`mutate.go`** — File mutation (append to line, check off task)
 - **`state.go`** — Current task state (start/stop/complete tracking)
-- **`frontmatter.go`** — YAML frontmatter parsing for tags/due dates
+- **`frontmatter.go`** — YAML frontmatter parsing for tags/due dates/status
 - **`main.go`** — CLI subcommand dispatch (list, do, stop, complete, current, tags)
 
 ### Lua plugin (`lua/taskbuffer/`)
 
-- **`init.lua`** — Config, setup(), public API
-- **`buffer.lua`** — Taskfile buffer management, refresh, autocmds
-- **`keymaps.lua`** — Buffer-local keymaps for task manipulation
+- **`init.lua`** — Setup(), public API entry points
+- **`config.lua`** — Defaults, validation, path expansion, config JSON serialization
+- **`buffer.lua`** — Taskfile buffer management, refresh, state tracking
+- **`autocmds.lua`** — BufEnter/BufLeave autocommands for taskfile refresh
+- **`keymaps.lua`** — Global, taskfile, and markdown keymaps
+- **`commands.lua`** — `:Tasks`, `:TasksClear`, `:TasksUndated` command registration
 - **`tags.lua`** — Telescope tag picker
+- **`undo.lua`** — Undo/redo stack for date shift operations
+- **`util.lua`** — File I/O, date manipulation, taskfile line parsing
+- **`health.lua`** — `:checkhealth taskbuffer` diagnostics
 
 ### Plugin files
 
-- **`plugin/taskbuffer.lua`** — Lazy-loaded `:Tasks` and `:TasksClear` commands
+- **`plugin/taskbuffer.lua`** — Lazy-loaded `:Tasks`, `:TasksClear`, and `:TasksUndated` commands
 - **`ftdetect/taskfile.vim`** — Filetype detection for `.taskfile`
 - **`syntax/taskfile.vim`** — Syntax highlighting
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ require("taskbuffer").setup({
     horizons_overlap = "sorted",   -- "sorted", "first_match", or "narrowest"
     week_start = "monday",         -- first day of the week
 
+    -- Frontmatter configuration
+    frontmatter = {
+        due_key = "due",         -- YAML key for the due date field
+        inherit_due = true,      -- undated tasks inherit the file's frontmatter due date
+        require_tags = {},       -- only inherit due if file has these frontmatter tags
+        status = {
+            key = "status",              -- YAML key for status field
+            done_values = { "done", "complete" },  -- values that mark a file as complete
+        },
+    },
+
     -- Task syntax formats (passed to Go binary)
     formats = {
         date = "%Y-%m-%d",
@@ -94,7 +105,7 @@ require("taskbuffer").setup({
         duration = "<{n}m>",
         tag_prefix = "#",
         checkbox = { open = "- [ ]", done = "- [x]", irrelevant = "- [-]" },
-        date_wrapper = { "(@[[", "]])" },
+        date_wrapper = { "(@[[", "]]", ")" },
         marker_prefix = "::",
     },
 
@@ -106,7 +117,6 @@ require("taskbuffer").setup({
             check_off       = "<leader>tx",
             irrelevant      = "<leader>ti",
             undo_irrelevant = "<leader>tu",
-            quickfix        = "<M-C-q>",
             note            = "<leader>ev",
         },
         taskfile = {
@@ -120,10 +130,15 @@ require("taskbuffer").setup({
             toggle_undated     = "<leader>ts",
             shift_date_back    = "<M-Left>",
             shift_date_forward = "<M-Right>",
+            set_date_today     = "<C-T>",
+            quickfix           = "<M-C-q>",
+            undo               = true,
+            redo               = true,
         },
         markdown = {
             shift_date_back    = "<M-Left>",
             shift_date_forward = "<M-Right>",
+            set_date_today     = "<C-T>",
         },
     },
 })
@@ -174,6 +189,26 @@ require("taskbuffer").setup({
 - `"first_match"`: task appears only in the first matching horizon
 - `"narrowest"`: task appears only in the narrowest matching horizon
 
+### Frontmatter
+
+taskbuffer reads YAML frontmatter from markdown files to enrich tasks:
+
+- **Tag inheritance**: Tags from the frontmatter `tags` field are merged with inline `#tags` on each task.
+- **Due date inheritance**: When `inherit_due` is enabled (the default), undated tasks inherit the file's frontmatter due date. This is useful for project notes where all tasks share a deadline.
+- **Status filtering**: Files whose frontmatter status matches a `done_values` entry (e.g. `status: done`) are automatically excluded from the task list.
+- **Project tasks**: Files with a `project` tag and a frontmatter due date appear as a synthetic "project" task in the taskfile, sorted after regular tasks with the same date.
+
+The `require_tags` option restricts due date inheritance to files that have specific frontmatter tags. For example, `require_tags = { "project" }` means only files tagged `project` will have their frontmatter due date inherited by undated tasks.
+
+### Health Check
+
+Run `:checkhealth taskbuffer` to verify your setup. The health check validates:
+- Neovim version (>= 0.10)
+- Go binary is built and executable
+- ripgrep is available
+- Source directories exist
+- telescope.nvim availability (optional)
+
 ## Task Syntax
 
 Tasks are standard markdown checkboxes with optional metadata:
@@ -223,7 +258,7 @@ Full example:
 The Go binary can also be used directly:
 
 ```bash
-task list [--tag TAG] [-markers]   # List tasks (default)
+task list [--tag TAG] [--markers] [--ignore-undated]  # List tasks (default)
 task do                            # Pick and start a task (fzf)
 task stop                          # Stop the current task
 task complete                      # Complete the current task
@@ -255,7 +290,6 @@ task --config '{"state_dir":"/tmp/state"}' current
 | Check off | `<leader>tx` | Quick check-off (no marker) |
 | Irrelevant | `<leader>ti` | Mark task irrelevant |
 | Undo irrelevant | `<leader>tu` | Undo irrelevant |
-| Quickfix | `<M-C-q>` | Send visual selection to quickfix |
 | Note | `<leader>ev` | Insert a dated note entry |
 
 ### Taskfile buffer
@@ -263,22 +297,29 @@ task --config '{"state_dir":"/tmp/state"}' current
 | Action | Default | Description |
 |--------|---------|-------------|
 | Start task | `<leader>tb` | Start timer for task under cursor |
-| Go to file | `gf` | Jump to source file location |
+| Go to file | `gf` / `<CR>` | Jump to source file location |
 | Irrelevant | `<leader>ti` | Mark task irrelevant |
 | Undo irrelevant | `<leader>tu` | Undo irrelevant |
 | Filter tags | `#` | Open Telescope tag picker |
 | Reset filters | `<leader>tt` | Clear all filters |
 | Toggle markers | `<leader>tj` | Show/hide `::` markers |
 | Toggle undated | `<leader>ts` | Show/hide undated tasks |
-| Shift date back | `<M-Left>` | Move due date earlier |
-| Shift date forward | `<M-Right>` | Move due date later |
+| Shift date back | `<M-Left>` | Move due date earlier (accepts count) |
+| Shift date forward | `<M-Right>` | Move due date later (accepts count) |
+| Set date today | `<C-T>` | Set due date to today |
+| Quickfix | `<M-C-q>` | Send visual selection to quickfix |
+| Undo | `u` (auto-detect) | Undo last date change |
+| Redo | `<C-r>` (auto-detect) | Redo last date change |
+
+Date shift, set today, and quickfix also work in visual mode on multiple tasks.
 
 ### Markdown files
 
 | Action | Default | Description |
 |--------|---------|-------------|
-| Shift date back | `<M-Left>` | Move due date earlier |
-| Shift date forward | `<M-Right>` | Move due date later |
+| Shift date back | `<M-Left>` | Move due date earlier (accepts count) |
+| Shift date forward | `<M-Right>` | Move due date later (accepts count) |
+| Set date today | `<C-T>` | Set due date to today |
 
 ## Architecture
 
@@ -289,9 +330,9 @@ Neovim <── buffer.lua reads .taskfile <────────────�
          keymaps.lua calls Go binary for mutations (defer, irrelevant, etc.)
 ```
 
-**Go binary** (`go/`): Scanning (`scan.go`), parsing (`parse.go`), formatting (`format.go`), file mutation (`mutate.go`), timer state (`state.go`), frontmatter parsing (`frontmatter.go`).
+**Go binary** (`go/`): Scanning (`scan.go`), parsing (`parse.go`), formatting (`format.go`), horizon logic (`horizon.go`), date/time format conversion (`timeformat.go`), file mutation (`mutate.go`), timer state (`state.go`), frontmatter parsing (`frontmatter.go`).
 
-**Lua plugin** (`lua/taskbuffer/`): Config (`config.lua`), setup and public API (`init.lua`), buffer management (`buffer.lua`), autocmds (`autocmds.lua`), keymaps (`keymaps.lua`), commands (`commands.lua`), Telescope tag picker (`tags.lua`), utilities (`util.lua`).
+**Lua plugin** (`lua/taskbuffer/`): Config (`config.lua`), setup and public API (`init.lua`), buffer management (`buffer.lua`), autocmds (`autocmds.lua`), keymaps (`keymaps.lua`), commands (`commands.lua`), Telescope tag picker (`tags.lua`), undo/redo stack (`undo.lua`), utilities (`util.lua`), health check (`health.lua`).
 
 ## Contributing
 

--- a/doc/taskbuffer.txt
+++ b/doc/taskbuffer.txt
@@ -95,6 +95,17 @@ option not specified falls back to its default value.
       horizons_overlap = "sorted",
       week_start = "monday",
 
+      -- Frontmatter configuration
+      frontmatter = {
+          due_key = "due",
+          inherit_due = true,
+          require_tags = {},
+          status = {
+              key = "status",
+              done_values = { "done", "complete" },
+          },
+      },
+
       -- Task syntax formats (passed to Go binary)
       formats = {
           date = "%Y-%m-%d",
@@ -118,7 +129,6 @@ option not specified falls back to its default value.
               check_off       = "<leader>tx",
               irrelevant      = "<leader>ti",
               undo_irrelevant = "<leader>tu",
-              quickfix        = "<M-C-q>",
               note            = "<leader>ev",
           },
           taskfile = {
@@ -132,10 +142,15 @@ option not specified falls back to its default value.
               toggle_undated     = "<leader>ts",
               shift_date_back    = "<M-Left>",
               shift_date_forward = "<M-Right>",
+              set_date_today     = "<C-T>",
+              quickfix           = "<M-C-q>",
+              undo               = true,
+              redo               = true,
           },
           markdown = {
               shift_date_back    = "<M-Left>",
               shift_date_forward = "<M-Right>",
+              set_date_today     = "<C-T>",
           },
       },
   })
@@ -233,6 +248,36 @@ Known limitations:
 - Changing the date format mid-stream means existing tasks in the old
   format will not parse. Migrate existing tasks manually.
 
+                                                  *taskbuffer-frontmatter*
+Frontmatter ~
+
+taskbuffer reads YAML frontmatter from markdown files to enrich tasks:
+
+- Tag inheritance: Tags from the frontmatter `tags` field are merged
+  with inline `#tags` on each task.
+- Due date inheritance: When `inherit_due` is enabled (the default),
+  undated tasks inherit the file's frontmatter due date.
+- Status filtering: Files whose frontmatter status matches a
+  `done_values` entry (e.g. `status: done`) are excluded from the
+  task list.
+- Project tasks: Files with a `project` tag and a frontmatter due
+  date appear as a synthetic project task, sorted after regular tasks
+  with the same date.
+
+`require_tags` restricts due date inheritance to files with specific
+frontmatter tags. For example, setting `require_tags = { "project" }`
+means only files tagged `project` will inherit frontmatter due dates.
+
+                                                   *taskbuffer-health*
+Health check ~
+
+Run `:checkhealth taskbuffer` to verify your setup. Checks:
+- Neovim version (>= 0.10)
+- Go binary is built and executable
+- ripgrep is available
+- Source directories exist
+- telescope.nvim availability (optional)
+
 ==============================================================================
 5. COMMANDS                                         *taskbuffer-commands*
 
@@ -260,15 +305,13 @@ Global (all filetypes) ~
   `<leader>tx`        Quick check-off (no marker)
   `<leader>ti`        Mark task irrelevant
   `<leader>tu`        Undo irrelevant
-  `<M-C-q>`           Send visual selection to quickfix
   `<leader>ev`        Insert a dated note entry
 
 Taskfile buffer ~
 
   Key               Action ~
   `<leader>tb`        Start timer for task under cursor
-  `gf`                Jump to source file location
-  `<CR>`              Jump to source file location
+  `gf` / `<CR>`       Jump to source file location
   `<leader>ti`        Mark task irrelevant
   `<leader>tu`        Undo irrelevant
   `#`                 Open Telescope tag picker
@@ -277,12 +320,20 @@ Taskfile buffer ~
   `<leader>ts`        Toggle undated task visibility
   `<M-Left>`          Move due date earlier (accepts count)
   `<M-Right>`         Move due date later (accepts count)
+  `<C-T>`             Set due date to today
+  `<M-C-q>`           Send visual selection to quickfix
+  `u`                 Undo last date change (auto-detect)
+  `<C-r>`             Redo last date change (auto-detect)
+
+Date shift, set today, and quickfix also work in visual mode on
+multiple tasks.
 
 Markdown files ~
 
   Key               Action ~
   `<M-Left>`          Move due date earlier (accepts count)
   `<M-Right>`         Move due date later (accepts count)
+  `<C-T>`             Set due date to today
 
 ==============================================================================
 7. TASK SYNTAX                                       *taskbuffer-syntax*

--- a/go/date_validation_test.go
+++ b/go/date_validation_test.go
@@ -1,0 +1,527 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// invalidDateCases covers all categories of invalid dates for reuse across surfaces.
+var invalidDateCases = []struct {
+	name    string
+	dateStr string // YYYY-MM-DD format
+}{
+	// Month out of range
+	{"month 00", "2026-00-15"},
+	{"month 13", "2026-13-01"},
+	{"month 99", "2026-99-01"},
+
+	// Day out of range
+	{"day 00", "2026-01-00"},
+	{"day 32", "2026-01-32"},
+	{"day 99", "2026-01-99"},
+
+	// Impossible month/day combos (30-day months)
+	{"Apr 31", "2026-04-31"},
+	{"Jun 31", "2026-06-31"},
+	{"Sep 31", "2026-09-31"},
+	{"Nov 31", "2026-11-31"},
+
+	// February edge cases
+	{"Feb 30", "2026-02-30"},
+	{"Feb 31", "2026-02-31"},
+	{"Feb 29 non-leap", "2025-02-29"},
+	{"Feb 29 century non-leap", "2100-02-29"},
+}
+
+// validDateCases ensures valid dates are not falsely flagged.
+var validDateCases = []struct {
+	name    string
+	dateStr string
+}{
+	{"Jan 01", "2026-01-01"},
+	{"Dec 31", "2026-12-31"},
+	{"Feb 28 non-leap", "2025-02-28"},
+	{"Feb 29 leap", "2024-02-29"},
+	{"Feb 29 century leap", "2000-02-29"},
+	{"Apr 30", "2026-04-30"},
+	{"Jun 30", "2026-06-30"},
+}
+
+// =============================================================================
+// Inline due dates
+// =============================================================================
+
+func TestDateValidation_InlineDates_Strict(t *testing.T) {
+	ctx := NewParseContext(Config{Strict: true})
+	var dateErrors []DateError
+	ctx.dateErrors = &dateErrors
+
+	for _, tt := range invalidDateCases {
+		t.Run(tt.name, func(t *testing.T) {
+			dateErrors = dateErrors[:0]
+			input := "- [ ] Task (@[[" + tt.dateStr + "]])"
+			task, err := ParseTask(rawMatch(input), ctx)
+			if err != nil {
+				t.Fatalf("strict mode should not return error, got: %v", err)
+			}
+			if task.DueDate != nil {
+				t.Error("expected nil DueDate for invalid date")
+			}
+			if len(dateErrors) != 1 {
+				t.Fatalf("expected 1 DateError, got %d", len(dateErrors))
+			}
+			de := dateErrors[0]
+			if de.DateStr != tt.dateStr {
+				t.Errorf("DateStr = %q, want %q", de.DateStr, tt.dateStr)
+			}
+			if de.Context != "inline due date" {
+				t.Errorf("Context = %q, want %q", de.Context, "inline due date")
+			}
+			if de.FilePath != "adversarial.md" {
+				t.Errorf("FilePath = %q, want %q", de.FilePath, "adversarial.md")
+			}
+			if de.LineNumber != 1 {
+				t.Errorf("LineNumber = %d, want 1", de.LineNumber)
+			}
+		})
+	}
+}
+
+func TestDateValidation_InlineDates_StrictPreservesBody(t *testing.T) {
+	ctx := NewParseContext(Config{Strict: true})
+	var dateErrors []DateError
+	ctx.dateErrors = &dateErrors
+
+	input := "- [ ] Important task #work (@[[2026-13-01]])"
+	task, err := ParseTask(rawMatch(input), ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if task.Body != "Important task" {
+		t.Errorf("body = %q, want %q", task.Body, "Important task")
+	}
+	if len(task.Tags) != 1 || task.Tags[0] != "work" {
+		t.Errorf("tags = %v, want [work]", task.Tags)
+	}
+	if task.DueDate != nil {
+		t.Error("DueDate should be nil for invalid date")
+	}
+}
+
+func TestDateValidation_InlineDates_NonStrict(t *testing.T) {
+	ctx := DefaultParseContext()
+
+	for _, tt := range invalidDateCases {
+		t.Run(tt.name, func(t *testing.T) {
+			input := "- [ ] Task (@[[" + tt.dateStr + "]])"
+			_, err := ParseTask(rawMatch(input), ctx)
+			if err == nil {
+				t.Error("non-strict mode should return error for invalid date")
+			}
+		})
+	}
+}
+
+func TestDateValidation_InlineDates_ValidDates(t *testing.T) {
+	ctx := NewParseContext(Config{Strict: true})
+	var dateErrors []DateError
+	ctx.dateErrors = &dateErrors
+
+	for _, tt := range validDateCases {
+		t.Run(tt.name, func(t *testing.T) {
+			dateErrors = dateErrors[:0]
+			input := "- [ ] Task (@[[" + tt.dateStr + "]])"
+			task, err := ParseTask(rawMatch(input), ctx)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if task.DueDate == nil {
+				t.Error("expected non-nil DueDate for valid date")
+			}
+			if len(dateErrors) != 0 {
+				t.Errorf("expected 0 DateErrors, got %d: %v", len(dateErrors), dateErrors)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// Marker dates
+// =============================================================================
+
+func TestDateValidation_MarkerDates_Strict(t *testing.T) {
+	ctx := NewParseContext(Config{Strict: true})
+	var dateErrors []DateError
+	ctx.dateErrors = &dateErrors
+
+	for _, tt := range invalidDateCases {
+		t.Run(tt.name, func(t *testing.T) {
+			dateErrors = dateErrors[:0]
+			input := "- [ ] Task (@[[2026-01-15]]) ::start [[" + tt.dateStr + "]] 10:00"
+			task, err := ParseTask(rawMatch(input), ctx)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			// Task should still have valid inline date
+			if task.DueDate == nil {
+				t.Error("inline date should still be parsed")
+			}
+			// Marker should still be stored
+			if len(task.Markers) != 1 {
+				t.Fatalf("expected 1 marker, got %d", len(task.Markers))
+			}
+			if task.Markers[0].Date != tt.dateStr {
+				t.Errorf("marker date = %q, want %q", task.Markers[0].Date, tt.dateStr)
+			}
+			// Should have collected an error
+			if len(dateErrors) != 1 {
+				t.Fatalf("expected 1 DateError, got %d", len(dateErrors))
+			}
+			if !strings.Contains(dateErrors[0].Context, "marker (start)") {
+				t.Errorf("Context = %q, want to contain %q", dateErrors[0].Context, "marker (start)")
+			}
+		})
+	}
+}
+
+func TestDateValidation_MarkerDates_NonStrict(t *testing.T) {
+	ctx := DefaultParseContext()
+
+	// Non-strict: markers store whatever the regex matched, no validation
+	input := "- [ ] Task (@[[2026-01-15]]) ::start [[2026-13-45]] 10:00"
+	task, err := ParseTask(rawMatch(input), ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(task.Markers) != 1 {
+		t.Fatalf("expected 1 marker, got %d", len(task.Markers))
+	}
+	// Invalid date stored as-is in non-strict mode
+	if task.Markers[0].Date != "2026-13-45" {
+		t.Errorf("marker date = %q, want %q", task.Markers[0].Date, "2026-13-45")
+	}
+}
+
+func TestDateValidation_MarkerDates_ValidDates(t *testing.T) {
+	ctx := NewParseContext(Config{Strict: true})
+	var dateErrors []DateError
+	ctx.dateErrors = &dateErrors
+
+	for _, tt := range validDateCases {
+		t.Run(tt.name, func(t *testing.T) {
+			dateErrors = dateErrors[:0]
+			input := "- [ ] Task (@[[2026-01-15]]) ::complete [[" + tt.dateStr + "]] 14:00"
+			_, err := ParseTask(rawMatch(input), ctx)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(dateErrors) != 0 {
+				t.Errorf("expected 0 DateErrors for valid marker date, got %d", len(dateErrors))
+			}
+		})
+	}
+}
+
+func TestDateValidation_MarkerDates_MultipleMarkers(t *testing.T) {
+	ctx := NewParseContext(Config{Strict: true})
+	var dateErrors []DateError
+	ctx.dateErrors = &dateErrors
+
+	// Two markers, both invalid
+	input := "- [ ] Task (@[[2026-01-15]]) ::start [[2026-13-01]] 10:00 ::stop [[2026-00-15]] 11:00"
+	task, err := ParseTask(rawMatch(input), ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(task.Markers) != 2 {
+		t.Fatalf("expected 2 markers, got %d", len(task.Markers))
+	}
+	if len(dateErrors) != 2 {
+		t.Fatalf("expected 2 DateErrors, got %d", len(dateErrors))
+	}
+	if !strings.Contains(dateErrors[0].Context, "marker (start)") {
+		t.Errorf("first error Context = %q", dateErrors[0].Context)
+	}
+	if !strings.Contains(dateErrors[1].Context, "marker (stop)") {
+		t.Errorf("second error Context = %q", dateErrors[1].Context)
+	}
+}
+
+// =============================================================================
+// Frontmatter due dates
+// =============================================================================
+
+func writeFrontmatterFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	f := filepath.Join(dir, name)
+	if err := os.WriteFile(f, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func TestDateValidation_FrontmatterDue_Strict(t *testing.T) {
+	for _, tt := range invalidDateCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ResetFrontmatterCache()
+			dir := t.TempDir()
+			f := writeFrontmatterFile(t, dir, "test.md",
+				"---\ndue: \""+tt.dateStr+"\"\ntags:\n  - work\n---\n")
+
+			tasks := []Task{
+				{FilePath: f, LineNumber: 5, Body: "undated task"},
+			}
+			var dateErrors []DateError
+			MergeFrontmatterDue(tasks, FrontmatterConfig{}, "2006-01-02", &dateErrors)
+
+			if tasks[0].DueDate != nil {
+				t.Error("DueDate should remain nil for invalid frontmatter date")
+			}
+			if len(dateErrors) != 1 {
+				t.Fatalf("expected 1 DateError, got %d", len(dateErrors))
+			}
+			if dateErrors[0].Context != "frontmatter due" {
+				t.Errorf("Context = %q, want %q", dateErrors[0].Context, "frontmatter due")
+			}
+			if dateErrors[0].FilePath != f {
+				t.Errorf("FilePath = %q, want %q", dateErrors[0].FilePath, f)
+			}
+		})
+	}
+}
+
+func TestDateValidation_FrontmatterDue_NonStrict(t *testing.T) {
+	for _, tt := range invalidDateCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ResetFrontmatterCache()
+			dir := t.TempDir()
+			f := writeFrontmatterFile(t, dir, "test.md",
+				"---\ndue: \""+tt.dateStr+"\"\ntags:\n  - work\n---\n")
+
+			tasks := []Task{
+				{FilePath: f, LineNumber: 5, Body: "undated task"},
+			}
+			MergeFrontmatterDue(tasks, FrontmatterConfig{}, "2006-01-02", nil)
+
+			// Non-strict: silently skipped, no crash
+			if tasks[0].DueDate != nil {
+				t.Error("DueDate should remain nil for invalid frontmatter date")
+			}
+		})
+	}
+}
+
+func TestDateValidation_FrontmatterDue_ValidDates(t *testing.T) {
+	for _, tt := range validDateCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ResetFrontmatterCache()
+			dir := t.TempDir()
+			f := writeFrontmatterFile(t, dir, "test.md",
+				"---\ndue: \""+tt.dateStr+"\"\n---\n")
+
+			tasks := []Task{
+				{FilePath: f, LineNumber: 5, Body: "task"},
+			}
+			var dateErrors []DateError
+			MergeFrontmatterDue(tasks, FrontmatterConfig{}, "2006-01-02", &dateErrors)
+
+			if tasks[0].DueDate == nil {
+				t.Error("DueDate should be set for valid date")
+			}
+			if len(dateErrors) != 0 {
+				t.Errorf("expected 0 DateErrors, got %d", len(dateErrors))
+			}
+		})
+	}
+}
+
+// =============================================================================
+// ScanProjects (frontmatter project due dates)
+// =============================================================================
+
+func TestDateValidation_ScanProjects_Strict(t *testing.T) {
+	for _, tt := range invalidDateCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ResetFrontmatterCache()
+			dir := t.TempDir()
+			writeFrontmatterFile(t, dir, "project.md",
+				"---\ndue: \""+tt.dateStr+"\"\ntags:\n  - project\n---\n- project\n")
+
+			var dateErrors []DateError
+			tasks, err := ScanProjects("2006-01-02", FrontmatterConfig{}, &dateErrors, dir)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(tasks) != 0 {
+				t.Error("expected 0 tasks for invalid project date")
+			}
+			if len(dateErrors) != 1 {
+				t.Fatalf("expected 1 DateError, got %d", len(dateErrors))
+			}
+			if dateErrors[0].Context != "frontmatter project due" {
+				t.Errorf("Context = %q, want %q", dateErrors[0].Context, "frontmatter project due")
+			}
+		})
+	}
+}
+
+func TestDateValidation_ScanProjects_NonStrict(t *testing.T) {
+	for _, tt := range invalidDateCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ResetFrontmatterCache()
+			dir := t.TempDir()
+			writeFrontmatterFile(t, dir, "project.md",
+				"---\ndue: \""+tt.dateStr+"\"\ntags:\n  - project\n---\n- project\n")
+
+			tasks, err := ScanProjects("2006-01-02", FrontmatterConfig{}, nil, dir)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			// Non-strict: silently skipped
+			if len(tasks) != 0 {
+				t.Error("expected 0 tasks for invalid project date")
+			}
+		})
+	}
+}
+
+// =============================================================================
+// Error message formatting
+// =============================================================================
+
+func TestDateValidation_ErrorMessages(t *testing.T) {
+	t.Run("inline with line number", func(t *testing.T) {
+		e := DateError{
+			FilePath:   "/notes/daily.md",
+			LineNumber: 15,
+			DateStr:    "2026-13-01",
+			Context:    "inline due date",
+			Err:        errFromParse("2026-13-01"),
+		}
+		msg := e.Error()
+		if !strings.Contains(msg, "/notes/daily.md:15") {
+			t.Errorf("error should contain file:line, got: %s", msg)
+		}
+		if !strings.Contains(msg, "inline due date") {
+			t.Errorf("error should contain context, got: %s", msg)
+		}
+		if !strings.Contains(msg, "2026-13-01") {
+			t.Errorf("error should contain date string, got: %s", msg)
+		}
+	})
+
+	t.Run("frontmatter without line number", func(t *testing.T) {
+		e := DateError{
+			FilePath: "/notes/project.md",
+			DateStr:  "2026-02-30",
+			Context:  "frontmatter due",
+			Err:      errFromParse("2026-02-30"),
+		}
+		msg := e.Error()
+		// Should NOT have :0 in the output
+		if strings.Contains(msg, ":0:") {
+			t.Errorf("frontmatter error should not show line 0, got: %s", msg)
+		}
+		if !strings.Contains(msg, "/notes/project.md:") {
+			// Should just have the path without line
+			if !strings.Contains(msg, "/notes/project.md") {
+				t.Errorf("error should contain file path, got: %s", msg)
+			}
+		}
+	})
+
+	t.Run("marker with kind", func(t *testing.T) {
+		e := DateError{
+			FilePath:   "/notes/task.md",
+			LineNumber: 8,
+			DateStr:    "2026-04-31",
+			Context:    "marker (start)",
+			Err:        errFromParse("2026-04-31"),
+		}
+		msg := e.Error()
+		if !strings.Contains(msg, "marker (start)") {
+			t.Errorf("error should contain marker kind, got: %s", msg)
+		}
+	})
+}
+
+// =============================================================================
+// Multiple errors across surfaces
+// =============================================================================
+
+func TestDateValidation_MultipleErrorsCollected(t *testing.T) {
+	ctx := NewParseContext(Config{Strict: true})
+	var dateErrors []DateError
+	ctx.dateErrors = &dateErrors
+
+	// Task with invalid inline date
+	input1 := "- [ ] Task one (@[[2026-13-01]])"
+	_, _ = ParseTask(rawMatch(input1), ctx)
+
+	// Task with valid inline date but invalid marker
+	input2 := "- [ ] Task two (@[[2026-01-15]]) ::start [[2026-04-31]] 10:00"
+	_, _ = ParseTask(rawMatch(input2), ctx)
+
+	// Frontmatter with invalid date
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+	f := writeFrontmatterFile(t, dir, "bad-fm.md",
+		"---\ndue: \"2026-02-30\"\n---\n")
+	tasks := []Task{{FilePath: f, LineNumber: 5, Body: "undated"}}
+	MergeFrontmatterDue(tasks, FrontmatterConfig{}, "2006-01-02", &dateErrors)
+
+	if len(dateErrors) != 3 {
+		t.Fatalf("expected 3 DateErrors across surfaces, got %d:", len(dateErrors))
+	}
+
+	contexts := make(map[string]bool)
+	for _, e := range dateErrors {
+		contexts[e.Context] = true
+	}
+	for _, want := range []string{"inline due date", "marker (start)", "frontmatter due"} {
+		if !contexts[want] {
+			t.Errorf("missing error context %q in collected errors", want)
+		}
+	}
+}
+
+// =============================================================================
+// Strict mode does not affect non-date errors
+// =============================================================================
+
+func TestDateValidation_StrictDoesNotSuppressCheckboxErrors(t *testing.T) {
+	ctx := NewParseContext(Config{Strict: true})
+	var dateErrors []DateError
+	ctx.dateErrors = &dateErrors
+
+	// No checkbox — should still return error even in strict mode
+	_, err := ParseTask(RawMatch{Path: "test.md", LineNumber: 1, Text: "Not a task line"}, ctx)
+	if err == nil {
+		t.Error("expected error for missing checkbox even in strict mode")
+	}
+	if len(dateErrors) != 0 {
+		t.Error("non-date error should not be collected as DateError")
+	}
+}
+
+// =============================================================================
+// Nil collector safety
+// =============================================================================
+
+func TestDateValidation_NilCollectorSafe(t *testing.T) {
+	// Calling collectDateError with nil should not panic
+	collectDateError(nil, DateError{
+		FilePath: "test.md",
+		DateStr:  "2026-13-01",
+		Context:  "test",
+	})
+}
+
+// errFromParse generates a realistic parse error for test assertions.
+func errFromParse(dateStr string) error {
+	_, err := time.Parse("2006-01-02", dateStr)
+	return err
+}

--- a/go/fm_due_e2e_test.go
+++ b/go/fm_due_e2e_test.go
@@ -1,0 +1,1096 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+// fullPipeline runs the full cmdList-style pipeline against a vault:
+// Scan -> Parse -> MergeFrontmatterTags -> FilterCompleted -> MergeFrontmatterDue -> open filter
+func fullPipeline(t *testing.T, ctx *ParseContext, fmCfg FrontmatterConfig, paths ...string) []Task {
+	t.Helper()
+	matches, err := Scan(ctx, paths...)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	tasks := ParseTasks(matches, ctx)
+	MergeFrontmatterTags(tasks)
+	tasks = FilterCompletedFrontmatterTasks(tasks, fmCfg)
+	MergeFrontmatterDue(tasks, fmCfg, ctx.formats.GoDate, nil)
+	return tasks
+}
+
+func fullPipelineOpen(t *testing.T, ctx *ParseContext, fmCfg FrontmatterConfig, paths ...string) []Task {
+	t.Helper()
+	all := fullPipeline(t, ctx, fmCfg, paths...)
+	return openTasks(all)
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// =============================================================================
+// Basic Inheritance
+// =============================================================================
+
+func TestFMDue_BasicInheritance(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "basic-inherit.md")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+
+	// 3 open tasks: 2 undated (inherit FM 2026-04-15), 1 inline (2026-03-01)
+	if len(tasks) != 3 {
+		t.Fatalf("got %d open tasks, want 3", len(tasks))
+	}
+
+	for _, task := range tasks {
+		if task.DueDate == nil {
+			t.Errorf("task %q has nil DueDate after inheritance", task.Body)
+			continue
+		}
+		switch task.Body {
+		case "Undated task one", "Undated task two":
+			if task.DueDate.Format("2006-01-02") != "2026-04-15" {
+				t.Errorf("task %q: date = %s, want 2026-04-15", task.Body, task.DueDate.Format("2006-01-02"))
+			}
+		case "Dated task with inline":
+			if task.DueDate.Format("2006-01-02") != "2026-03-01" {
+				t.Errorf("task %q: date = %s, want 2026-03-01 (inline wins)", task.Body, task.DueDate.Format("2006-01-02"))
+			}
+		}
+	}
+}
+
+func TestFMDue_InlineAlwaysWins(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "basic-inherit.md")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+
+	task := findTask(tasks, "Dated task with inline")
+	if task == nil {
+		t.Fatal("inline dated task not found")
+	}
+	// FM due is 2026-04-15, inline is 2026-03-01 -- inline must win
+	if task.DueDate.Format("2006-01-02") != "2026-03-01" {
+		t.Errorf("inline date overridden by FM: got %s", task.DueDate.Format("2006-01-02"))
+	}
+}
+
+// =============================================================================
+// Completion Filtering
+// =============================================================================
+
+func TestFMDue_CompletedFileFiltersUndated(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "done-file.md")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+
+	// 2 undated tasks should be filtered, 1 inline-dated should survive
+	if len(tasks) != 1 {
+		bodies := taskBodies(tasks)
+		t.Fatalf("got %d tasks, want 1 (inline survivor only): %v", len(tasks), bodies)
+	}
+	if tasks[0].Body != "Inline dated task from done file" {
+		t.Errorf("wrong task survived: %q", tasks[0].Body)
+	}
+}
+
+func TestFMDue_CompleteStatusAlsoFilters(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "complete-status.md")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+
+	// status: complete should also trigger filtering (default done_values includes "complete")
+	if len(tasks) != 0 {
+		t.Errorf("expected 0 tasks from complete file, got %d: %v", len(tasks), taskBodies(tasks))
+	}
+}
+
+func TestFMDue_DoneMixedFileSurvivors(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "done-mixed.md")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+
+	// 2 undated filtered, 2 inline-dated survive
+	if len(tasks) != 2 {
+		t.Fatalf("got %d tasks, want 2: %v", len(tasks), taskBodies(tasks))
+	}
+	for _, task := range tasks {
+		if task.DueDate == nil {
+			t.Errorf("survivor %q should have inline date", task.Body)
+		}
+	}
+}
+
+func TestFMDue_ActiveFileNotFiltered(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "active-status.md")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+
+	// status: active is not in done_values, so undated tasks survive and inherit
+	// 2 open undated + 0 open inline (the [x] is done) = 2
+	if len(tasks) != 2 {
+		t.Fatalf("got %d open tasks from active file, want 2: %v", len(tasks), taskBodies(tasks))
+	}
+	for _, task := range tasks {
+		if task.DueDate == nil {
+			t.Errorf("task %q should have inherited FM date", task.Body)
+		}
+		if task.DueDate.Format("2006-01-02") != "2026-04-10" {
+			t.Errorf("task %q: date = %s, want 2026-04-10", task.Body, task.DueDate.Format("2006-01-02"))
+		}
+	}
+}
+
+// =============================================================================
+// No Due / No Frontmatter
+// =============================================================================
+
+func TestFMDue_NoDueInFrontmatter(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "no-due.md")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+
+	// FM has no due key, so tasks stay undated
+	for _, task := range tasks {
+		if task.DueDate != nil {
+			t.Errorf("task %q should remain undated (FM has no due), got %s", task.Body, task.DueDate.Format("2006-01-02"))
+		}
+	}
+}
+
+func TestFMDue_NoFrontmatterAtAll(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "no-frontmatter.md")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+
+	for _, task := range tasks {
+		if task.DueDate != nil {
+			t.Errorf("task %q should remain undated (no FM), got %s", task.Body, task.DueDate.Format("2006-01-02"))
+		}
+	}
+}
+
+// =============================================================================
+// InheritDue = false
+// =============================================================================
+
+func TestFMDue_InheritDueDisabled(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "basic-inherit.md")
+	fmCfg := FrontmatterConfig{InheritDue: boolPtr(false)}
+	tasks := fullPipelineOpen(t, DefaultParseContext(), fmCfg, f)
+
+	// With inherit_due=false, only the inline-dated task has a date
+	dated := 0
+	for _, task := range tasks {
+		if task.DueDate != nil {
+			dated++
+		}
+	}
+	if dated != 1 {
+		t.Errorf("expected 1 dated task (inline only), got %d", dated)
+	}
+}
+
+// =============================================================================
+// Custom Key Names
+// =============================================================================
+
+func TestFMDue_CustomDueKey(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "custom-key.md")
+	fmCfg := FrontmatterConfig{DueKey: "deadline"}
+	tasks := fullPipelineOpen(t, DefaultParseContext(), fmCfg, f)
+
+	if len(tasks) != 3 {
+		t.Fatalf("got %d tasks, want 3", len(tasks))
+	}
+
+	for _, task := range tasks {
+		if task.DueDate == nil {
+			t.Errorf("task %q has nil DueDate", task.Body)
+			continue
+		}
+		switch task.Body {
+		case "Task using deadline key", "Another deadline task":
+			if task.DueDate.Format("2006-01-02") != "2026-06-01" {
+				t.Errorf("task %q: inherited date = %s, want 2026-06-01", task.Body, task.DueDate.Format("2006-01-02"))
+			}
+		case "Inline overrides deadline":
+			if task.DueDate.Format("2006-01-02") != "2026-07-01" {
+				t.Errorf("task %q: inline date = %s, want 2026-07-01", task.Body, task.DueDate.Format("2006-01-02"))
+			}
+		}
+	}
+}
+
+func TestFMDue_CustomDueKeyDefaultIgnoresStandardDue(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "custom-key.md")
+	// Using default due_key="due" should NOT find "deadline"
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+
+	for _, task := range tasks {
+		if task.Body == "Task using deadline key" && task.DueDate != nil {
+			t.Error("default due_key should not read 'deadline' field")
+		}
+	}
+}
+
+func TestFMDue_CustomStatusKeyAndDoneValues(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "custom-status.md")
+	fmCfg := FrontmatterConfig{
+		DueKey:     "deadline",
+		StatusKey:  "state",
+		DoneValues: []string{"archived"},
+	}
+	tasks := fullPipelineOpen(t, DefaultParseContext(), fmCfg, f)
+
+	// state: archived with custom done_values=["archived"] should filter undated
+	// 2 undated filtered, 1 inline survives
+	if len(tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1 (inline survivor): %v", len(tasks), taskBodies(tasks))
+	}
+	if tasks[0].Body != "Inline dated in archived" {
+		t.Errorf("wrong survivor: %q", tasks[0].Body)
+	}
+}
+
+func TestFMDue_CustomStatusKeyNotMatchingDefault(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "custom-status.md")
+	// Default status_key="status" won't find "state: archived"
+	fmCfg := FrontmatterConfig{DueKey: "deadline"}
+	tasks := fullPipelineOpen(t, DefaultParseContext(), fmCfg, f)
+
+	// No filtering should happen (default status key "status" finds nothing)
+	// All 3 tasks should be present, 2 undated inherit deadline
+	if len(tasks) != 3 {
+		t.Fatalf("got %d tasks, want 3 (no filtering with default status key): %v", len(tasks), taskBodies(tasks))
+	}
+}
+
+// =============================================================================
+// Require Tags
+// =============================================================================
+
+func TestFMDue_RequireTagsSingleMatch(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	fmCfg := FrontmatterConfig{RequireTags: []string{"project"}}
+
+	hasTag := filepath.Join(vault, "require-tags.md")
+	missingTag := filepath.Join(vault, "missing-required-tag.md")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), fmCfg, hasTag, missingTag)
+
+	for _, task := range tasks {
+		switch task.Body {
+		case "Task in file with required tags":
+			if task.DueDate == nil {
+				t.Error("task with matching required tag should inherit FM due")
+			}
+		case "Task in file missing required tag":
+			if task.DueDate != nil {
+				t.Error("task without matching required tag should NOT inherit FM due")
+			}
+		}
+	}
+}
+
+func TestFMDue_RequireTagsMultipleMustAllMatch(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	// Require both "project" AND "important" -- require-tags.md has both
+	fmCfg := FrontmatterConfig{RequireTags: []string{"project", "important"}}
+	f := filepath.Join(vault, "require-tags.md")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), fmCfg, f)
+
+	if tasks[0].DueDate == nil {
+		t.Error("file has both required tags, should inherit")
+	}
+}
+
+func TestFMDue_RequireTagsPartialMatchFails(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	// Require "project" AND "secret" -- require-tags.md only has project+important
+	fmCfg := FrontmatterConfig{RequireTags: []string{"project", "secret"}}
+	f := filepath.Join(vault, "require-tags.md")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), fmCfg, f)
+
+	if tasks[0].DueDate != nil {
+		t.Error("file missing 'secret' tag, should NOT inherit")
+	}
+}
+
+func TestFMDue_EmptyRequireTagsAllowsAll(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	fmCfg := FrontmatterConfig{RequireTags: []string{}}
+	f := filepath.Join(vault, "basic-inherit.md")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), fmCfg, f)
+
+	undated := findTask(tasks, "Undated task one")
+	if undated == nil || undated.DueDate == nil {
+		t.Error("empty require_tags should allow all files to inherit")
+	}
+}
+
+// =============================================================================
+// Time Inheritance
+// =============================================================================
+
+func TestFMDue_InheritsTimeFromFM(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "due-with-time.md")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+
+	for _, task := range tasks {
+		switch task.Body {
+		case "Undated task inheriting time":
+			if task.DueDate == nil {
+				t.Error("should inherit FM due date")
+				continue
+			}
+			if task.DueDate.Format("2006-01-02") != "2026-04-15" {
+				t.Errorf("date = %s, want 2026-04-15", task.DueDate.Format("2006-01-02"))
+			}
+			if task.DueTime != "14:30" {
+				t.Errorf("time = %q, want 14:30", task.DueTime)
+			}
+		case "Inline has own time":
+			if task.DueTime != "09:00" {
+				t.Errorf("inline time = %q, want 09:00 (inline wins)", task.DueTime)
+			}
+		}
+	}
+}
+
+// =============================================================================
+// Bare YAML Date (auto-parsed by YAML v3 to time.Time)
+// =============================================================================
+
+func TestFMDue_BareYAMLDate(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "bare-date.md")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+
+	if len(tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(tasks))
+	}
+	if tasks[0].DueDate == nil {
+		t.Fatal("bare YAML date should be parsed and inherited")
+	}
+	if tasks[0].DueDate.Format("2006-01-02") != "2026-04-15" {
+		t.Errorf("date = %s, want 2026-04-15", tasks[0].DueDate.Format("2006-01-02"))
+	}
+}
+
+// =============================================================================
+// Mixed Files in Single Vault
+// =============================================================================
+
+func TestFMDue_MixedInlineAndUndated(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "mixed-inline-undated.md")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+
+	// 3 undated (inherit 2026-04-20), 1 inline (2026-03-10) = 4 open
+	if len(tasks) != 4 {
+		t.Fatalf("got %d open tasks, want 4: %v", len(tasks), taskBodies(tasks))
+	}
+
+	for _, task := range tasks {
+		if task.DueDate == nil {
+			t.Errorf("task %q should have a date", task.Body)
+			continue
+		}
+		if task.Body == "Has inline date" {
+			if task.DueDate.Format("2006-01-02") != "2026-03-10" {
+				t.Errorf("inline task date = %s, want 2026-03-10", task.DueDate.Format("2006-01-02"))
+			}
+		} else {
+			if task.DueDate.Format("2006-01-02") != "2026-04-20" {
+				t.Errorf("inherited task %q date = %s, want 2026-04-20", task.Body, task.DueDate.Format("2006-01-02"))
+			}
+		}
+	}
+}
+
+// =============================================================================
+// Full Vault Scan (all files together)
+// =============================================================================
+
+func TestFMDue_FullVaultDefaultConfig(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, vault)
+
+	// Verify key properties across the whole vault
+	taskMap := make(map[string]*Task)
+	for i := range tasks {
+		taskMap[tasks[i].Body] = &tasks[i]
+	}
+
+	// Tasks from done-file.md: only inline survivor
+	if _, ok := taskMap["Leftover undated task"]; ok {
+		t.Error("undated task from done file should be filtered")
+	}
+	if _, ok := taskMap["Inline dated task from done file"]; !ok {
+		t.Error("inline dated task from done file should survive")
+	}
+
+	// Tasks from no-due.md: should remain undated
+	if task, ok := taskMap["Undated task in no-due file"]; ok && task.DueDate != nil {
+		t.Error("task in no-due file should remain undated")
+	}
+
+	// Tasks from basic-inherit.md: undated should inherit
+	if task, ok := taskMap["Undated task one"]; ok {
+		if task.DueDate == nil || task.DueDate.Format("2006-01-02") != "2026-04-15" {
+			t.Errorf("basic inherit task: date = %v, want 2026-04-15", task.DueDate)
+		}
+	}
+
+	// No tasks from complete-status.md (all undated, file is "complete")
+	if _, ok := taskMap["Undated task in complete file"]; ok {
+		t.Error("undated task from complete file should be filtered")
+	}
+}
+
+// =============================================================================
+// Combined Weird Configs: multiple options set simultaneously
+// =============================================================================
+
+func TestFMDue_CustomKeyPlusRequireTags(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	fmCfg := FrontmatterConfig{
+		DueKey:      "deadline",
+		RequireTags: []string{"project"},
+	}
+	// custom-key.md: deadline: 2026-06-01, tags: [project] -> should inherit
+	// basic-inherit.md: due: 2026-04-15, tags: [work] -> "due" != "deadline", so no inherit
+	tasks := fullPipelineOpen(t, DefaultParseContext(), fmCfg,
+		filepath.Join(vault, "custom-key.md"),
+		filepath.Join(vault, "basic-inherit.md"),
+	)
+
+	for _, task := range tasks {
+		switch task.Body {
+		case "Task using deadline key":
+			if task.DueDate == nil || task.DueDate.Format("2006-01-02") != "2026-06-01" {
+				t.Errorf("custom-key task should inherit deadline, got %v", task.DueDate)
+			}
+		case "Undated task one":
+			// basic-inherit.md has "due" not "deadline", so no inheritance with custom key
+			if task.DueDate != nil {
+				t.Errorf("basic-inherit task should NOT inherit (wrong key name), got %s", task.DueDate.Format("2006-01-02"))
+			}
+		}
+	}
+}
+
+func TestFMDue_CustomKeyPlusCustomStatusPlusDoneValues(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	fmCfg := FrontmatterConfig{
+		DueKey:     "deadline",
+		StatusKey:  "state",
+		DoneValues: []string{"archived", "retired"},
+	}
+	// custom-status.md: deadline: 2026-06-15, state: archived -> should filter undated
+	tasks := fullPipelineOpen(t, DefaultParseContext(), fmCfg,
+		filepath.Join(vault, "custom-status.md"),
+	)
+
+	if len(tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1 (inline survivor): %v", len(tasks), taskBodies(tasks))
+	}
+	if tasks[0].Body != "Inline dated in archived" {
+		t.Errorf("wrong survivor: %q", tasks[0].Body)
+	}
+}
+
+func TestFMDue_InheritFalsePlusCompletionFiltering(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	fmCfg := FrontmatterConfig{InheritDue: boolPtr(false)}
+	// done-mixed.md: status: done, 2 undated + 2 inline
+	// With inherit_due=false: FilterCompleted still runs, removes undated from done files
+	// Then MergeFrontmatterDue is a no-op
+	tasks := fullPipelineOpen(t, DefaultParseContext(), fmCfg,
+		filepath.Join(vault, "done-mixed.md"),
+	)
+
+	// Only inline-dated tasks survive (completion filtering doesn't need inherit_due)
+	if len(tasks) != 2 {
+		t.Fatalf("got %d tasks, want 2 (inline only): %v", len(tasks), taskBodies(tasks))
+	}
+}
+
+func TestFMDue_RequireTagsPlusCompletionFiltering(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	fmCfg := FrontmatterConfig{RequireTags: []string{"cleanup"}}
+	// done-file.md: tags: [cleanup], status: done
+	// Undated tasks are filtered by completion filter (regardless of require_tags)
+	// require_tags only affects inheritance, not completion filtering
+	tasks := fullPipelineOpen(t, DefaultParseContext(), fmCfg,
+		filepath.Join(vault, "done-file.md"),
+	)
+
+	// Undated tasks from done file filtered, inline survives
+	if len(tasks) != 1 {
+		t.Fatalf("got %d, want 1: %v", len(tasks), taskBodies(tasks))
+	}
+}
+
+func TestFMDue_AllOptionsSimultaneous(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	fmCfg := FrontmatterConfig{
+		DueKey:      "deadline",
+		InheritDue:  boolPtr(true),
+		RequireTags: []string{"project"},
+		StatusKey:   "state",
+		DoneValues:  []string{"archived"},
+	}
+
+	tasks := fullPipelineOpen(t, DefaultParseContext(), fmCfg,
+		filepath.Join(vault, "custom-key.md"),     // deadline: 2026-06-01, tags: [project] -> inherit
+		filepath.Join(vault, "custom-status.md"),   // deadline: 2026-06-15, state: archived, tags: [old] -> filter undated (no "project" tag, but completion still filters)
+		filepath.Join(vault, "basic-inherit.md"),    // due: 2026-04-15 (wrong key), tags: [work] -> no inherit
+		filepath.Join(vault, "require-tags.md"),     // due: 2026-05-20 (wrong key), tags: [project, important] -> no inherit (wrong key)
+		filepath.Join(vault, "active-status.md"),    // due: 2026-04-10 (wrong key), state: active -> no inherit
+	)
+
+	for _, task := range tasks {
+		switch task.Body {
+		case "Task using deadline key", "Another deadline task":
+			// custom-key.md: has "deadline", has "project" tag -> inherits
+			if task.DueDate == nil || task.DueDate.Format("2006-01-02") != "2026-06-01" {
+				t.Errorf("task %q should inherit deadline 2026-06-01, got %v", task.Body, task.DueDate)
+			}
+		case "Inline overrides deadline":
+			// Has inline date, should be preserved
+			if task.DueDate == nil || task.DueDate.Format("2006-01-02") != "2026-07-01" {
+				t.Errorf("task %q inline date should be 2026-07-01, got %v", task.Body, task.DueDate)
+			}
+		case "Task in archived file", "Another archived task":
+			// custom-status.md: state=archived matches DoneValues, these are undated -> filtered
+			t.Errorf("task %q from archived file should be filtered", task.Body)
+		case "Inline dated in archived":
+			// Has inline date, survives completion filter
+			if task.DueDate == nil || task.DueDate.Format("2006-01-02") != "2026-08-01" {
+				t.Errorf("task %q date = %v, want 2026-08-01", task.Body, task.DueDate)
+			}
+		case "Undated task one", "Undated task two":
+			// basic-inherit.md: "due" key != "deadline" key -> no inheritance
+			if task.DueDate != nil {
+				t.Errorf("task %q should NOT inherit (wrong key), got %s", task.Body, task.DueDate.Format("2006-01-02"))
+			}
+		case "Task in file with required tags":
+			// require-tags.md: "due" key != "deadline" key -> no inheritance
+			if task.DueDate != nil {
+				t.Errorf("task %q: 'due' != 'deadline', should not inherit", task.Body)
+			}
+		}
+	}
+}
+
+// =============================================================================
+// Pipeline Ordering Matters
+// =============================================================================
+
+func TestFMDue_FilterBeforeInherit(t *testing.T) {
+	// Verify that filtering happens BEFORE inheritance.
+	// If we inherit first, undated tasks from done files would get a date,
+	// then the filter wouldn't know they were originally undated.
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "done-file.md")
+
+	// Run pipeline in WRONG order: inherit then filter
+	ctx := DefaultParseContext()
+	matches, _ := Scan(ctx, f)
+	tasks := ParseTasks(matches, ctx)
+	MergeFrontmatterTags(tasks)
+	// WRONG: inherit first
+	MergeFrontmatterDue(tasks, FrontmatterConfig{}, ctx.formats.GoDate, nil)
+	// Now all tasks have dates, filter won't remove any
+	wrongResult := FilterCompletedFrontmatterTasks(openTasks(tasks), FrontmatterConfig{})
+
+	// CORRECT order
+	ResetFrontmatterCache()
+	correctResult := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+
+	// Wrong order should have more tasks (undated got dates before filtering)
+	if len(wrongResult) <= len(correctResult) {
+		t.Skipf("pipeline ordering test inconclusive: wrong=%d, correct=%d", len(wrongResult), len(correctResult))
+	}
+	// Correct pipeline: only inline-dated task survives
+	if len(correctResult) != 1 {
+		t.Errorf("correct pipeline: got %d tasks, want 1", len(correctResult))
+	}
+}
+
+// =============================================================================
+// Format Output Integration
+// =============================================================================
+
+func TestFMDue_FormatOutputShowsInheritedDates(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "basic-inherit.md")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+
+	now := time.Date(2026, 4, 15, 10, 0, 0, 0, time.Local)
+	output := FormatTaskfile(tasks, now, FormatOpts{})
+
+	// Inherited tasks should appear under "Today" (since FM due = 2026-04-15 = now)
+	if !strings.Contains(output, "# Today") {
+		t.Error("expected Today header for inherited due date")
+	}
+	if !strings.Contains(output, "Undated task one") {
+		t.Error("inherited task should appear in formatted output")
+	}
+}
+
+func TestFMDue_FormatIgnoreUndatedStillShowsInherited(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "basic-inherit.md")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+
+	now := time.Date(2026, 4, 15, 10, 0, 0, 0, time.Local)
+	output := FormatTaskfile(tasks, now, FormatOpts{IgnoreUndated: true})
+
+	// After inheritance, these tasks have dates, so IgnoreUndated should NOT hide them
+	if !strings.Contains(output, "Undated task one") {
+		t.Error("inherited tasks have dates and should show with IgnoreUndated")
+	}
+}
+
+func TestFMDue_FormatTagFilterOnInheritedTasks(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "basic-inherit.md")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+
+	now := time.Date(2026, 4, 15, 10, 0, 0, 0, time.Local)
+	// basic-inherit.md has FM tags: [work], so MergeFrontmatterTags adds "work" to all tasks
+	output := FormatTaskfile(tasks, now, FormatOpts{TagFilter: []string{"work"}})
+
+	if !strings.Contains(output, "Undated task one") {
+		t.Error("FM tag 'work' should match inherited tasks")
+	}
+
+	// Filter by nonexistent tag
+	output = FormatTaskfile(tasks, now, FormatOpts{TagFilter: []string{"nonexistent"}})
+	if strings.Contains(output, "Undated task one") {
+		t.Error("nonexistent tag should not match")
+	}
+}
+
+// =============================================================================
+// cmdList End-to-End
+// =============================================================================
+
+func TestFMDue_CmdListEndToEnd(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cfg := Config{Frontmatter: FrontmatterConfig{}}
+	err := cmdList([]string{vault}, DefaultParseContext(), nil, cfg)
+
+	w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := make([]byte, 128*1024)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	// Inherited tasks should appear
+	if !strings.Contains(output, "Undated task one") {
+		t.Error("expected inherited task in cmdList output")
+	}
+	// Filtered tasks should NOT appear
+	if strings.Contains(output, "Leftover undated task") {
+		t.Error("undated task from done file should be filtered in cmdList")
+	}
+	// Inline from done file should appear
+	if !strings.Contains(output, "Inline dated task from done file") {
+		t.Error("inline dated from done file should survive in cmdList")
+	}
+}
+
+func TestFMDue_CmdListCustomConfig(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cfg := Config{
+		Frontmatter: FrontmatterConfig{
+			DueKey:     "deadline",
+			StatusKey:  "state",
+			DoneValues: []string{"archived"},
+		},
+	}
+	err := cmdList(
+		[]string{filepath.Join(vault, "custom-key.md"), filepath.Join(vault, "custom-status.md")},
+		DefaultParseContext(), nil, cfg,
+	)
+
+	w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := make([]byte, 128*1024)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	// custom-key.md tasks should inherit deadline
+	if !strings.Contains(output, "Task using deadline key") {
+		t.Error("custom-key tasks should inherit from 'deadline' field")
+	}
+	// custom-status.md undated tasks should be filtered (state: archived)
+	if strings.Contains(output, "Task in archived file") {
+		t.Error("undated tasks from archived file should be filtered")
+	}
+	// Inline from archived file survives
+	if !strings.Contains(output, "Inline dated in archived") {
+		t.Error("inline dated from archived file should survive")
+	}
+}
+
+// =============================================================================
+// ScanProjects with FrontmatterConfig
+// =============================================================================
+
+func TestFMDue_ScanProjectsCustomDoneValues(t *testing.T) {
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+
+	// Project with custom done status
+	f := filepath.Join(dir, "project.md")
+	os.WriteFile(f, []byte("---\ntags:\n  - project\ndue: 2026-07-01\nstatus: shipped\n---\n# Project\n"), 0644)
+
+	// Default done_values: shipped is NOT in ["done", "complete"]
+	tasks, err := ScanProjects("2006-01-02", FrontmatterConfig{}, nil, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 {
+		t.Errorf("default config: expected 1 project (shipped != done), got %d", len(tasks))
+	}
+
+	// Custom done_values including "shipped"
+	ResetFrontmatterCache()
+	tasks, err = ScanProjects("2006-01-02", FrontmatterConfig{DoneValues: []string{"shipped", "done"}}, nil, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("custom config: expected 0 projects (shipped is done), got %d", len(tasks))
+	}
+}
+
+func TestFMDue_ScanProjectsCustomDueKey(t *testing.T) {
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+
+	f := filepath.Join(dir, "project.md")
+	os.WriteFile(f, []byte("---\ntags:\n  - project\ndeadline: 2026-07-01\nstatus: active\n---\n# Project\n"), 0644)
+
+	// Default due_key="due" won't find "deadline"
+	tasks, err := ScanProjects("2006-01-02", FrontmatterConfig{}, nil, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("default key: expected 0 (no 'due' field), got %d", len(tasks))
+	}
+
+	// Custom due_key="deadline"
+	ResetFrontmatterCache()
+	tasks, err = ScanProjects("2006-01-02", FrontmatterConfig{DueKey: "deadline"}, nil, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("custom key: expected 1 project, got %d", len(tasks))
+	}
+	if tasks[0].DueDate.Format("2006-01-02") != "2026-07-01" {
+		t.Errorf("date = %s, want 2026-07-01", tasks[0].DueDate.Format("2006-01-02"))
+	}
+}
+
+func TestFMDue_ScanProjectsCustomStatusKey(t *testing.T) {
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+
+	f := filepath.Join(dir, "project.md")
+	os.WriteFile(f, []byte("---\ntags:\n  - project\ndue: 2026-07-01\nstate: retired\n---\n# Project\n"), 0644)
+
+	// Default status_key="status" won't find "state: retired"
+	tasks, err := ScanProjects("2006-01-02", FrontmatterConfig{}, nil, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 {
+		t.Errorf("default status key: expected 1 (status not found = active), got %d", len(tasks))
+	}
+
+	// Custom status_key="state", done_values=["retired"]
+	ResetFrontmatterCache()
+	tasks, err = ScanProjects("2006-01-02", FrontmatterConfig{StatusKey: "state", DoneValues: []string{"retired"}}, nil, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("custom status key: expected 0 (state=retired is done), got %d", len(tasks))
+	}
+}
+
+// =============================================================================
+// Edge Cases & Stress
+// =============================================================================
+
+func TestFMDue_EmptyVault(t *testing.T) {
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, dir)
+	if len(tasks) != 0 {
+		t.Errorf("empty vault should produce 0 tasks, got %d", len(tasks))
+	}
+}
+
+func TestFMDue_AllTasksHaveInlineDates(t *testing.T) {
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "all-inline.md")
+	os.WriteFile(f, []byte("---\ndue: 2026-12-25\nstatus: done\n---\n- [ ] Task A (@[[2026-01-01]])\n- [ ] Task B (@[[2026-02-01]])\n"), 0644)
+
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+
+	// Both have inline dates, so they survive done-file filtering
+	if len(tasks) != 2 {
+		t.Fatalf("got %d tasks, want 2 (inline dates survive done file)", len(tasks))
+	}
+}
+
+func TestFMDue_FileWithDueButNoDoneStatus(t *testing.T) {
+	// File has due but no status field at all -> not "done", tasks should inherit
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "no-status.md")
+	os.WriteFile(f, []byte("---\ndue: 2026-09-01\n---\n- [ ] Task no status\n"), 0644)
+
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+
+	if len(tasks) != 1 || tasks[0].DueDate == nil {
+		t.Error("task should inherit due from file with no status field")
+	}
+}
+
+func TestFMDue_DoneStatusButNoDue(t *testing.T) {
+	// File has status: done but no due field -> no filtering happens
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "done-no-due.md")
+	os.WriteFile(f, []byte("---\nstatus: done\n---\n- [ ] Task in done file without due\n"), 0644)
+
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+
+	// FilterCompletedFrontmatterTasks requires BOTH due AND done status
+	if len(tasks) != 1 {
+		t.Errorf("task should survive: done file has no due field, got %d", len(tasks))
+	}
+}
+
+func TestFMDue_CaseInsensitiveDoneValues(t *testing.T) {
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+
+	f := filepath.Join(dir, "upper-done.md")
+	os.WriteFile(f, []byte("---\ndue: 2026-03-01\nstatus: DONE\n---\n- [ ] Should be filtered\n"), 0644)
+
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{}, f)
+	if len(tasks) != 0 {
+		t.Error("'DONE' (uppercase) should match default done_values (case insensitive)")
+	}
+}
+
+func TestFMDue_MultipleFilesShareSameConfig(t *testing.T) {
+	// Ensure the pipeline handles multiple files correctly with a single config
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	tasks := fullPipelineOpen(t, DefaultParseContext(), FrontmatterConfig{},
+		filepath.Join(vault, "basic-inherit.md"),
+		filepath.Join(vault, "done-file.md"),
+		filepath.Join(vault, "no-due.md"),
+		filepath.Join(vault, "no-frontmatter.md"),
+		filepath.Join(vault, "active-status.md"),
+	)
+
+	// Count tasks per source behavior
+	inherited := 0
+	filtered := 0
+	undated := 0
+	for _, task := range tasks {
+		if task.DueDate != nil {
+			inherited++
+		} else {
+			undated++
+		}
+	}
+
+	// basic-inherit: 2 inherited + 1 inline = 3 dated
+	// done-file: 2 filtered, 1 inline survived = 1 dated
+	// no-due: 2 undated
+	// no-frontmatter: 2 undated
+	// active-status: 2 inherited (active, not filtered)
+	// Totals: 7 dated, 4 undated
+	_ = filtered // not directly countable from output
+	if inherited < 6 {
+		t.Errorf("expected at least 6 dated tasks across files, got %d", inherited)
+	}
+	if undated < 4 {
+		t.Errorf("expected at least 4 undated tasks (from no-due + no-frontmatter), got %d", undated)
+	}
+}
+
+// =============================================================================
+// SortLast: Project Tasks Sort Below Their File's Tasks
+// =============================================================================
+
+func TestFMDue_ProjectSortsBelowInheritedTasks(t *testing.T) {
+	ResetFrontmatterCache()
+	vault := vaultPath(t, "fm-due-vault")
+	f := filepath.Join(vault, "project-sort.md")
+
+	// Run full pipeline to get regular tasks with inherited dates
+	ctx := DefaultParseContext()
+	tasks := fullPipelineOpen(t, ctx, FrontmatterConfig{}, f)
+
+	// Get synthetic project task
+	projects, err := ScanProjects(ctx.formats.GoDate, FrontmatterConfig{}, nil, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(projects) != 1 {
+		t.Fatalf("expected 1 project task, got %d", len(projects))
+	}
+
+	all := append(tasks, projects...)
+	now := time.Date(2026, 4, 15, 10, 0, 0, 0, time.Local)
+	output := FormatTaskfile(all, now, FormatOpts{})
+
+	firstIdx := strings.Index(output, "First subtask")
+	secondIdx := strings.Index(output, "Second subtask")
+	// Find project-sort body line (not filepath occurrences) by looking for the tab-delimited body
+	projIdx := strings.Index(output, "\t project-sort \t")
+
+	if projIdx < 0 || firstIdx < 0 || secondIdx < 0 {
+		t.Fatalf("missing tasks in output:\n%s", output)
+	}
+	if projIdx < firstIdx {
+		t.Errorf("project task appeared before 'First subtask' in output:\n%s", output)
+	}
+	if projIdx < secondIdx {
+		t.Errorf("project task appeared before 'Second subtask' in output:\n%s", output)
+	}
+}
+
+func TestFMDue_SortLastFieldSetOnProjectTasks(t *testing.T) {
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+
+	f := filepath.Join(dir, "proj.md")
+	os.WriteFile(f, []byte("---\ntags:\n  - project\ndue: 2026-07-01\n---\n- [ ] A task\n"), 0644)
+
+	projects, err := ScanProjects("2006-01-02", FrontmatterConfig{}, nil, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(projects) != 1 {
+		t.Fatalf("expected 1 project, got %d", len(projects))
+	}
+	if !projects[0].SortLast {
+		t.Error("ScanProjects should set SortLast=true on synthetic project tasks")
+	}
+}
+
+func TestFMDue_SortLastComparatorUnit(t *testing.T) {
+	// Two tasks with same date, filepath, and line number -- SortLast breaks tie
+	date := time.Date(2026, 4, 15, 0, 0, 0, 0, time.Local)
+	regular := Task{
+		FilePath:   "/notes/tasks.md",
+		LineNumber: 1,
+		Body:       "regular-task",
+		DueDate:    &date,
+		Status:     "open",
+		SortLast:   false,
+	}
+	synthetic := Task{
+		FilePath:   "/notes/tasks.md",
+		LineNumber: 1,
+		Body:       "synthetic-task",
+		DueDate:    &date,
+		Status:     "open",
+		SortLast:   true,
+	}
+
+	// Format with synthetic first to test that sort reorders
+	tasks := []Task{synthetic, regular}
+	now := time.Date(2026, 4, 15, 10, 0, 0, 0, time.Local)
+	output := FormatTaskfile(tasks, now, FormatOpts{})
+
+	regIdx := strings.Index(output, "regular-task")
+	synIdx := strings.Index(output, "synthetic-task")
+	if regIdx < 0 || synIdx < 0 {
+		t.Fatalf("missing tasks in output:\n%s", output)
+	}
+	if synIdx < regIdx {
+		t.Errorf("SortLast task should appear after regular task:\n%s", output)
+	}
+}

--- a/go/format.go
+++ b/go/format.go
@@ -213,6 +213,9 @@ func FormatTaskfile(tasks []Task, now time.Time, opts FormatOpts) string {
 		if dated[i].FilePath != dated[j].FilePath {
 			return dated[i].FilePath < dated[j].FilePath
 		}
+		if dated[i].SortLast != dated[j].SortLast {
+			return !dated[i].SortLast
+		}
 		return dated[i].LineNumber < dated[j].LineNumber
 	})
 
@@ -220,6 +223,9 @@ func FormatTaskfile(tasks []Task, now time.Time, opts FormatOpts) string {
 	sort.Slice(undated, func(i, j int) bool {
 		if undated[i].FilePath != undated[j].FilePath {
 			return undated[i].FilePath < undated[j].FilePath
+		}
+		if undated[i].SortLast != undated[j].SortLast {
+			return !undated[i].SortLast
 		}
 		return undated[i].LineNumber < undated[j].LineNumber
 	})

--- a/go/frontmatter.go
+++ b/go/frontmatter.go
@@ -2,18 +2,73 @@ package main
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
 
 // Frontmatter represents parsed YAML frontmatter from a markdown file.
+// Raw holds the full map for configurable key access; Tags is always
+// extracted from the "tags" key for convenience.
 type Frontmatter struct {
-	Tags   []string `yaml:"tags"`
-	Due    string   `yaml:"due"`    // "YYYY-MM-DD" or "YYYY-MM-DD HH:MM"
-	Status string   `yaml:"status"` // e.g. "active", "completed", "done"
+	Raw  map[string]interface{}
+	Tags []string
+}
+
+// GetString returns the string value for a key from the raw frontmatter map.
+// Handles YAML v3's automatic time.Time parsing of date-like strings.
+func (fm *Frontmatter) GetString(key string) string {
+	if fm == nil || fm.Raw == nil {
+		return ""
+	}
+	v, ok := fm.Raw[key]
+	if !ok {
+		return ""
+	}
+	switch val := v.(type) {
+	case string:
+		return val
+	case int:
+		return fmt.Sprintf("%d", val)
+	case float64:
+		return fmt.Sprintf("%g", val)
+	case time.Time:
+		// YAML v3 parses bare dates (e.g. "2026-04-01") as time.Time.
+		// Format back to date string, including time if non-zero.
+		if val.Hour() == 0 && val.Minute() == 0 && val.Second() == 0 {
+			return val.Format("2006-01-02")
+		}
+		return val.Format("2006-01-02 15:04")
+	default:
+		return ""
+	}
+}
+
+// GetStringSlice returns a []string for a key from the raw frontmatter map.
+func (fm *Frontmatter) GetStringSlice(key string) []string {
+	if fm == nil || fm.Raw == nil {
+		return nil
+	}
+	v, ok := fm.Raw[key]
+	if !ok {
+		return nil
+	}
+	switch val := v.(type) {
+	case []interface{}:
+		result := make([]string, 0, len(val))
+		for _, item := range val {
+			if s, ok := item.(string); ok {
+				result = append(result, s)
+			}
+		}
+		return result
+	default:
+		return nil
+	}
 }
 
 type frontmatterCache struct {
@@ -94,13 +149,26 @@ func parseFrontmatterFromFile(filePath string) (*Frontmatter, error) {
 		return nil, nil
 	}
 
-	// Parse YAML
-	var fm Frontmatter
-	if err := yaml.Unmarshal([]byte(strings.Join(lines, "\n")), &fm); err != nil {
+	// Parse YAML into raw map
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal([]byte(strings.Join(lines, "\n")), &raw); err != nil {
 		return nil, nil // malformed YAML, skip silently
 	}
 
-	return &fm, nil
+	fm := &Frontmatter{Raw: raw}
+
+	// Extract tags from the "tags" key (always hardcoded)
+	if tagsRaw, ok := raw["tags"]; ok {
+		if tagSlice, ok := tagsRaw.([]interface{}); ok {
+			for _, item := range tagSlice {
+				if s, ok := item.(string); ok {
+					fm.Tags = append(fm.Tags, s)
+				}
+			}
+		}
+	}
+
+	return fm, nil
 }
 
 // MergeFrontmatterTags reads frontmatter tags for each task's file
@@ -122,4 +190,115 @@ func MergeFrontmatterTags(tasks []Task) {
 			}
 		}
 	}
+}
+
+// MergeFrontmatterDue inherits due dates from frontmatter for tasks that
+// have no inline due date. Respects FrontmatterConfig settings.
+func MergeFrontmatterDue(tasks []Task, fmCfg FrontmatterConfig, goDateFmt string, dateErrors *[]DateError) {
+	if !fmCfg.InheritDueResolved() {
+		return
+	}
+
+	for i := range tasks {
+		if tasks[i].DueDate != nil {
+			continue
+		}
+
+		fm, err := ParseFrontmatter(tasks[i].FilePath)
+		if err != nil || fm == nil {
+			continue
+		}
+
+		dueStr := fm.GetString(fmCfg.DueKeyResolved())
+		if dueStr == "" {
+			continue
+		}
+
+		// Check required tags
+		reqTags := fmCfg.RequireTagsResolved()
+		if len(reqTags) > 0 {
+			fmTagSet := make(map[string]bool, len(fm.Tags))
+			for _, t := range fm.Tags {
+				fmTagSet[t] = true
+			}
+			allPresent := true
+			for _, rt := range reqTags {
+				if !fmTagSet[rt] {
+					allPresent = false
+					break
+				}
+			}
+			if !allPresent {
+				continue
+			}
+		}
+
+		// Parse due date
+		parts := strings.SplitN(dueStr, " ", 2)
+		dueDate, err := time.Parse(goDateFmt, parts[0])
+		if err != nil {
+			collectDateError(dateErrors, DateError{
+				FilePath: tasks[i].FilePath,
+				DateStr:  parts[0],
+				Context:  "frontmatter due",
+				Err:      err,
+			})
+			continue
+		}
+		tasks[i].DueDate = &dueDate
+		if len(parts) == 2 {
+			tasks[i].DueTime = strings.TrimSpace(parts[1])
+		}
+	}
+}
+
+// FilterCompletedFrontmatterTasks removes tasks from files whose frontmatter
+// indicates completion, but only tasks that have no inline due date (DueDate == nil).
+// Run this BEFORE MergeFrontmatterDue so inherited-only tasks get filtered out.
+func FilterCompletedFrontmatterTasks(tasks []Task, fmCfg FrontmatterConfig) []Task {
+	dueKey := fmCfg.DueKeyResolved()
+	statusKey := fmCfg.StatusKeyResolved()
+	doneValues := fmCfg.DoneValuesResolved()
+
+	if len(doneValues) == 0 {
+		return tasks
+	}
+
+	doneSet := make(map[string]bool, len(doneValues))
+	for _, v := range doneValues {
+		doneSet[strings.ToLower(v)] = true
+	}
+
+	// Build set of completed file paths (files with due + done status)
+	completedFiles := make(map[string]bool)
+	// Cache lookups per file to avoid redundant parsing
+	checkedFiles := make(map[string]bool)
+
+	result := make([]Task, 0, len(tasks))
+	for _, t := range tasks {
+		if t.DueDate != nil {
+			// Has inline date -- always keep
+			result = append(result, t)
+			continue
+		}
+
+		// Check if file is completed
+		if _, checked := checkedFiles[t.FilePath]; !checked {
+			checkedFiles[t.FilePath] = true
+			fm, err := ParseFrontmatter(t.FilePath)
+			if err == nil && fm != nil {
+				fmDue := fm.GetString(dueKey)
+				fmStatus := strings.ToLower(fm.GetString(statusKey))
+				if fmDue != "" && doneSet[fmStatus] {
+					completedFiles[t.FilePath] = true
+				}
+			}
+		}
+
+		if completedFiles[t.FilePath] {
+			continue // exclude undated task from completed file
+		}
+		result = append(result, t)
+	}
+	return result
 }

--- a/go/frontmatter_test.go
+++ b/go/frontmatter_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestParseFrontmatterTags_WithTags(t *testing.T) {
@@ -108,5 +109,237 @@ func TestMergeFrontmatterTags_MergesAndDeduplicates(t *testing.T) {
 		if !tagSet[want] {
 			t.Errorf("missing tag %q in %v", want, tasks[0].Tags)
 		}
+	}
+}
+
+func TestParseFrontmatter_CustomDueKey(t *testing.T) {
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "test.md")
+	os.WriteFile(f, []byte("---\ndeadline: 2026-04-01\ntags:\n  - work\n---\n"), 0644)
+
+	fm, err := ParseFrontmatter(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fm.GetString("deadline"); got != "2026-04-01" {
+		t.Errorf("GetString(deadline) = %q, want 2026-04-01", got)
+	}
+	if got := fm.GetString("due"); got != "" {
+		t.Errorf("GetString(due) = %q, want empty", got)
+	}
+}
+
+func TestParseFrontmatter_CustomStatusKey(t *testing.T) {
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "test.md")
+	os.WriteFile(f, []byte("---\nstate: finished\n---\n"), 0644)
+
+	fm, err := ParseFrontmatter(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fm.GetString("state"); got != "finished" {
+		t.Errorf("GetString(state) = %q, want finished", got)
+	}
+}
+
+func TestMergeFrontmatterDue_InheritsWhenNoDueDate(t *testing.T) {
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "test.md")
+	os.WriteFile(f, []byte("---\ndue: 2026-05-10\ntags:\n  - work\n---\n"), 0644)
+
+	tasks := []Task{
+		{FilePath: f, LineNumber: 5, Body: "undated task"},
+	}
+	MergeFrontmatterDue(tasks, FrontmatterConfig{}, "2006-01-02", nil)
+
+	if tasks[0].DueDate == nil {
+		t.Fatal("expected DueDate to be set from frontmatter")
+	}
+	want := time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC)
+	if !tasks[0].DueDate.Equal(want) {
+		t.Errorf("DueDate = %v, want %v", tasks[0].DueDate, want)
+	}
+}
+
+func TestMergeFrontmatterDue_InlineWins(t *testing.T) {
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "test.md")
+	os.WriteFile(f, []byte("---\ndue: 2026-05-10\n---\n"), 0644)
+
+	inlineDate := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+	tasks := []Task{
+		{FilePath: f, LineNumber: 5, Body: "dated task", DueDate: &inlineDate},
+	}
+	MergeFrontmatterDue(tasks, FrontmatterConfig{}, "2006-01-02", nil)
+
+	if !tasks[0].DueDate.Equal(inlineDate) {
+		t.Errorf("DueDate changed to %v, want inline date %v", tasks[0].DueDate, inlineDate)
+	}
+}
+
+func TestMergeFrontmatterDue_InheritDueFalse(t *testing.T) {
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "test.md")
+	os.WriteFile(f, []byte("---\ndue: 2026-05-10\n---\n"), 0644)
+
+	inheritFalse := false
+	tasks := []Task{
+		{FilePath: f, LineNumber: 5, Body: "undated task"},
+	}
+	MergeFrontmatterDue(tasks, FrontmatterConfig{InheritDue: &inheritFalse}, "2006-01-02", nil)
+
+	if tasks[0].DueDate != nil {
+		t.Errorf("DueDate should be nil when inherit_due=false, got %v", tasks[0].DueDate)
+	}
+}
+
+func TestMergeFrontmatterDue_RequireTags(t *testing.T) {
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+
+	// File with required tag
+	f1 := filepath.Join(dir, "has-tag.md")
+	os.WriteFile(f1, []byte("---\ndue: 2026-05-10\ntags:\n  - project\n---\n"), 0644)
+
+	// File without required tag
+	f2 := filepath.Join(dir, "no-tag.md")
+	os.WriteFile(f2, []byte("---\ndue: 2026-05-10\ntags:\n  - notes\n---\n"), 0644)
+
+	tasks := []Task{
+		{FilePath: f1, LineNumber: 5, Body: "task in project file"},
+		{FilePath: f2, LineNumber: 5, Body: "task in notes file"},
+	}
+	fmCfg := FrontmatterConfig{RequireTags: []string{"project"}}
+	MergeFrontmatterDue(tasks, fmCfg, "2006-01-02", nil)
+
+	if tasks[0].DueDate == nil {
+		t.Error("task with matching tag should inherit due date")
+	}
+	if tasks[1].DueDate != nil {
+		t.Error("task without matching tag should not inherit due date")
+	}
+}
+
+func TestMergeFrontmatterDue_WithTime(t *testing.T) {
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "test.md")
+	os.WriteFile(f, []byte("---\ndue: \"2026-05-10 14:30\"\n---\n"), 0644)
+
+	tasks := []Task{
+		{FilePath: f, LineNumber: 5, Body: "timed task"},
+	}
+	MergeFrontmatterDue(tasks, FrontmatterConfig{}, "2006-01-02", nil)
+
+	if tasks[0].DueDate == nil {
+		t.Fatal("expected DueDate to be set")
+	}
+	if tasks[0].DueTime != "14:30" {
+		t.Errorf("DueTime = %q, want 14:30", tasks[0].DueTime)
+	}
+}
+
+func TestMergeFrontmatterDue_CustomDueKey(t *testing.T) {
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "test.md")
+	os.WriteFile(f, []byte("---\ndeadline: 2026-06-01\n---\n"), 0644)
+
+	tasks := []Task{
+		{FilePath: f, LineNumber: 5, Body: "custom key task"},
+	}
+	fmCfg := FrontmatterConfig{DueKey: "deadline"}
+	MergeFrontmatterDue(tasks, fmCfg, "2006-01-02", nil)
+
+	if tasks[0].DueDate == nil {
+		t.Fatal("expected DueDate from custom key 'deadline'")
+	}
+	want := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	if !tasks[0].DueDate.Equal(want) {
+		t.Errorf("DueDate = %v, want %v", tasks[0].DueDate, want)
+	}
+}
+
+func TestFilterCompletedFrontmatterTasks_ExcludesInheritedOnly(t *testing.T) {
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "done-file.md")
+	os.WriteFile(f, []byte("---\ndue: 2026-05-01\nstatus: done\ntags:\n  - project\n---\n"), 0644)
+
+	tasks := []Task{
+		{FilePath: f, LineNumber: 5, Body: "undated from done file"},        // DueDate nil
+		{FilePath: f, LineNumber: 6, Body: "another undated from done file"}, // DueDate nil
+	}
+
+	result := FilterCompletedFrontmatterTasks(tasks, FrontmatterConfig{})
+	if len(result) != 0 {
+		t.Errorf("expected 0 tasks (all undated from done file), got %d", len(result))
+	}
+}
+
+func TestFilterCompletedFrontmatterTasks_KeepsInlineDated(t *testing.T) {
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "done-file.md")
+	os.WriteFile(f, []byte("---\ndue: 2026-05-01\nstatus: done\n---\n"), 0644)
+
+	inlineDate := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+	tasks := []Task{
+		{FilePath: f, LineNumber: 5, Body: "undated task"},                                // should be filtered
+		{FilePath: f, LineNumber: 6, Body: "inline dated task", DueDate: &inlineDate}, // should survive
+	}
+
+	result := FilterCompletedFrontmatterTasks(tasks, FrontmatterConfig{})
+	if len(result) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(result))
+	}
+	if result[0].Body != "inline dated task" {
+		t.Errorf("wrong task survived: %q", result[0].Body)
+	}
+}
+
+func TestFilterCompletedFrontmatterTasks_CustomDoneValues(t *testing.T) {
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "archived.md")
+	os.WriteFile(f, []byte("---\ndue: 2026-05-01\nstatus: archived\n---\n"), 0644)
+
+	tasks := []Task{
+		{FilePath: f, LineNumber: 5, Body: "task in archived file"},
+	}
+
+	// Default done values don't include "archived"
+	result := FilterCompletedFrontmatterTasks(tasks, FrontmatterConfig{})
+	if len(result) != 1 {
+		t.Error("task should survive with default done values (archived not in list)")
+	}
+
+	// Custom done values include "archived"
+	ResetFrontmatterCache()
+	result = FilterCompletedFrontmatterTasks(tasks, FrontmatterConfig{DoneValues: []string{"archived", "done"}})
+	if len(result) != 0 {
+		t.Error("task should be filtered with custom done values including 'archived'")
+	}
+}
+
+func TestFilterCompletedFrontmatterTasks_KeepsFromActiveFiles(t *testing.T) {
+	ResetFrontmatterCache()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "active.md")
+	os.WriteFile(f, []byte("---\ndue: 2026-05-01\nstatus: active\n---\n"), 0644)
+
+	tasks := []Task{
+		{FilePath: f, LineNumber: 5, Body: "undated task from active file"},
+	}
+
+	result := FilterCompletedFrontmatterTasks(tasks, FrontmatterConfig{})
+	if len(result) != 1 {
+		t.Error("task from active file should not be filtered")
 	}
 }

--- a/go/main.go
+++ b/go/main.go
@@ -30,6 +30,75 @@ func (s *sourceList) Set(val string) error {
 	return nil
 }
 
+// FrontmatterConfig holds configurable frontmatter key names and behavior.
+type FrontmatterConfig struct {
+	DueKey      string   `json:"due_key"`
+	InheritDue  *bool    `json:"inherit_due"`
+	RequireTags []string `json:"require_tags"`
+	StatusKey   string   `json:"status_key"`
+	DoneValues  []string `json:"done_values"`
+}
+
+// DueKeyResolved returns the configured due key or the default "due".
+func (fc FrontmatterConfig) DueKeyResolved() string {
+	if fc.DueKey != "" {
+		return fc.DueKey
+	}
+	return "due"
+}
+
+// InheritDueResolved returns whether due date inheritance is enabled (default true).
+func (fc FrontmatterConfig) InheritDueResolved() bool {
+	if fc.InheritDue != nil {
+		return *fc.InheritDue
+	}
+	return true
+}
+
+// RequireTagsResolved returns the required tags or nil.
+func (fc FrontmatterConfig) RequireTagsResolved() []string {
+	return fc.RequireTags
+}
+
+// StatusKeyResolved returns the configured status key or the default "status".
+func (fc FrontmatterConfig) StatusKeyResolved() string {
+	if fc.StatusKey != "" {
+		return fc.StatusKey
+	}
+	return "status"
+}
+
+// DoneValuesResolved returns the configured done values or defaults.
+func (fc FrontmatterConfig) DoneValuesResolved() []string {
+	if len(fc.DoneValues) > 0 {
+		return fc.DoneValues
+	}
+	return []string{"done", "complete"}
+}
+
+// DateError represents an invalid date found during parsing.
+type DateError struct {
+	FilePath   string // source file
+	LineNumber int    // 0 for frontmatter-level errors
+	DateStr    string // the raw string that failed to parse
+	Context    string // "inline due date", "frontmatter due", "marker (start)", etc.
+	Err        error  // underlying parse error
+}
+
+func (e DateError) Error() string {
+	if e.LineNumber > 0 {
+		return fmt.Sprintf("date error: %s:%d: invalid %s %q: %v", e.FilePath, e.LineNumber, e.Context, e.DateStr, e.Err)
+	}
+	return fmt.Sprintf("date error: %s: invalid %s %q: %v", e.FilePath, e.Context, e.DateStr, e.Err)
+}
+
+// collectDateError appends a DateError to the collector if non-nil.
+func collectDateError(errs *[]DateError, e DateError) {
+	if errs != nil {
+		*errs = append(*errs, e)
+	}
+}
+
 // Config holds runtime configuration passed via --config JSON.
 type Config struct {
 	StateDir        string            `json:"state_dir"`
@@ -42,6 +111,8 @@ type Config struct {
 	Horizons        []HorizonSpec     `json:"horizons,omitempty"`
 	HorizonsOverlap string            `json:"horizons_overlap,omitempty"`
 	WeekStart       string            `json:"week_start,omitempty"`
+	Frontmatter     FrontmatterConfig `json:"frontmatter,omitempty"`
+	Strict          bool              `json:"strict,omitempty"`
 }
 
 // Verbose controls whether parse warnings are printed to stderr.
@@ -102,6 +173,11 @@ func cmdList(notesPaths []string, ctx *ParseContext, args []string, cfg Config) 
 		return err
 	}
 
+	var dateErrors []DateError
+	if ctx.strict {
+		ctx.dateErrors = &dateErrors
+	}
+
 	matches, err := Scan(ctx, notesPaths...)
 	if err != nil {
 		return fmt.Errorf("scan: %w", err)
@@ -109,8 +185,10 @@ func cmdList(notesPaths []string, ctx *ParseContext, args []string, cfg Config) 
 
 	allTasks := ParseTasks(matches, ctx)
 	MergeFrontmatterTags(allTasks)
+	allTasks = FilterCompletedFrontmatterTasks(allTasks, cfg.Frontmatter)
+	MergeFrontmatterDue(allTasks, cfg.Frontmatter, ctx.formats.GoDate, ctx.dateErrors)
 
-	projectTasks, err := ScanProjects(ctx.formats.GoDate, notesPaths...)
+	projectTasks, err := ScanProjects(ctx.formats.GoDate, cfg.Frontmatter, ctx.dateErrors, notesPaths...)
 	if err != nil {
 		return fmt.Errorf("scan projects: %w", err)
 	}
@@ -121,6 +199,13 @@ func cmdList(notesPaths []string, ctx *ParseContext, args []string, cfg Config) 
 		if t.Status == "open" {
 			tasks = append(tasks, t)
 		}
+	}
+
+	if ctx.strict && len(dateErrors) > 0 {
+		for _, e := range dateErrors {
+			fmt.Fprintf(os.Stderr, "%s\n", e.Error())
+		}
+		return fmt.Errorf("%d invalid date(s) found", len(dateErrors))
 	}
 
 	now := time.Now().In(time.Local)
@@ -164,6 +249,9 @@ func cmdDo(notesPaths []string, ctx *ParseContext, cfg Config) error {
 		return fmt.Errorf("scan: %w", err)
 	}
 	allTasks := ParseTasks(matches, ctx)
+	MergeFrontmatterTags(allTasks)
+	allTasks = FilterCompletedFrontmatterTasks(allTasks, cfg.Frontmatter)
+	MergeFrontmatterDue(allTasks, cfg.Frontmatter, ctx.formats.GoDate, nil)
 	var todayTasks []Task
 	for _, t := range allTasks {
 		if t.Status == "open" && t.DueDate != nil && t.DueDate.Format(ctx.formats.GoDate) == today {
@@ -292,7 +380,7 @@ func cmdCurrent(cfg Config) error {
 	return nil
 }
 
-func cmdTags(notesPaths []string, ctx *ParseContext) error {
+func cmdTags(notesPaths []string, ctx *ParseContext, cfg Config) error {
 	matches, err := Scan(ctx, notesPaths...)
 	if err != nil {
 		return fmt.Errorf("scan: %w", err)
@@ -301,7 +389,7 @@ func cmdTags(notesPaths []string, ctx *ParseContext) error {
 	allTasks := ParseTasks(matches, ctx)
 	MergeFrontmatterTags(allTasks)
 
-	projectTasks, err := ScanProjects(ctx.formats.GoDate, notesPaths...)
+	projectTasks, err := ScanProjects(ctx.formats.GoDate, cfg.Frontmatter, nil, notesPaths...)
 	if err != nil {
 		return fmt.Errorf("scan projects: %w", err)
 	}
@@ -581,7 +669,7 @@ func main() {
 	case "current":
 		err = cmdCurrent(cfg)
 	case "tags":
-		err = cmdTags(notesPaths, ctx)
+		err = cmdTags(notesPaths, ctx, cfg)
 	case "defer":
 		err = cmdDefer(ctx, subArgs)
 	case "irrelevant":

--- a/go/parse.go
+++ b/go/parse.go
@@ -18,6 +18,7 @@ type Task struct {
 	Tags       []string
 	Status     string // "open", "done", "irrelevant"
 	Markers    []Marker
+	SortLast   bool // synthetic tasks (projects) sort after real tasks
 }
 
 type Marker struct {
@@ -40,6 +41,8 @@ type ParseContext struct {
 	scanPattern   string            // rg pattern for scanning
 	checkbox      map[string]string // status_name -> checkbox string (for mutations)
 	formats       DateTimeFormats   // resolved date/time formats
+	strict        bool              // when true, collect date errors instead of skipping
+	dateErrors    *[]DateError      // collector for date validation errors (nil = ignore)
 }
 
 // NewParseContext builds a ParseContext from a Config, falling back to defaults
@@ -47,6 +50,7 @@ type ParseContext struct {
 func NewParseContext(cfg Config) *ParseContext {
 	ctx := &ParseContext{
 		durationRe: regexp.MustCompile(`<(\d+)m>`),
+		strict:     cfg.Strict,
 	}
 
 	// Checkbox config
@@ -204,10 +208,22 @@ func ParseTask(match RawMatch, ctx *ParseContext) (Task, error) {
 		}
 		d, err := time.Parse(ctx.formats.GoDate, dateStr)
 		if err != nil {
-			return Task{}, fmt.Errorf("unparseable date %q: %w", dateStr, err)
+			if ctx.strict {
+				collectDateError(ctx.dateErrors, DateError{
+					FilePath:   match.Path,
+					LineNumber: match.LineNumber,
+					DateStr:    dateStr,
+					Context:    "inline due date",
+					Err:        err,
+				})
+				// treat as undated — continue parsing body/tags/markers
+			} else {
+				return Task{}, fmt.Errorf("unparseable date %q: %w", dateStr, err)
+			}
+		} else {
+			dueDate = &d
+			dueTime = dateMatch[2]
 		}
-		dueDate = &d
-		dueTime = dateMatch[2]
 		dateGroupIdx = strings.Index(line, dateGroupFull)
 	}
 
@@ -238,6 +254,18 @@ func ParseTask(match RawMatch, ctx *ParseContext) (Task, error) {
 		}
 		mm := ctx.markerRe.FindStringSubmatch(seg)
 		if mm != nil {
+			if ctx.strict && mm[2] != "" {
+				_, err := time.Parse(ctx.formats.GoDate, mm[2])
+				if err != nil {
+					collectDateError(ctx.dateErrors, DateError{
+						FilePath:   match.Path,
+						LineNumber: match.LineNumber,
+						DateStr:    mm[2],
+						Context:    fmt.Sprintf("marker (%s)", mm[1]),
+						Err:        err,
+					})
+				}
+			}
 			markers = append(markers, Marker{
 				Kind: mm[1],
 				Date: mm[2],

--- a/go/scan.go
+++ b/go/scan.go
@@ -157,7 +157,7 @@ func Scan(ctx *ParseContext, notesPaths ...string) ([]RawMatch, error) {
 
 // ScanProjects finds markdown files with "project" in frontmatter tags and a due date,
 // returning them as Task entries. goDateFmt is the Go time layout for parsing dates.
-func ScanProjects(goDateFmt string, notesPaths ...string) ([]Task, error) {
+func ScanProjects(goDateFmt string, fmCfg FrontmatterConfig, dateErrors *[]DateError, notesPaths ...string) ([]Task, error) {
 	paths := expandGlobs(notesPaths)
 	if len(paths) == 0 {
 		return nil, nil
@@ -194,20 +194,38 @@ func ScanProjects(goDateFmt string, notesPaths ...string) ([]Task, error) {
 				break
 			}
 		}
-		if !hasProject || fm.Due == "" {
+		dueKey := fmCfg.DueKeyResolved()
+		statusKey := fmCfg.StatusKeyResolved()
+		doneValues := fmCfg.DoneValuesResolved()
+
+		fmDue := fm.GetString(dueKey)
+		if !hasProject || fmDue == "" {
 			continue
 		}
 
-		s := strings.ToLower(fm.Status)
-		if s == "completed" || s == "done" {
+		fmStatus := strings.ToLower(fm.GetString(statusKey))
+		isDone := false
+		for _, dv := range doneValues {
+			if fmStatus == strings.ToLower(dv) {
+				isDone = true
+				break
+			}
+		}
+		if isDone {
 			continue
 		}
 
 		var dueDate time.Time
 		var dueTime string
-		parts := strings.SplitN(fm.Due, " ", 2)
+		parts := strings.SplitN(fmDue, " ", 2)
 		dueDate, err = time.Parse(goDateFmt, parts[0])
 		if err != nil {
+			collectDateError(dateErrors, DateError{
+				FilePath: filePath,
+				DateStr:  parts[0],
+				Context:  "frontmatter project due",
+				Err:      err,
+			})
 			continue
 		}
 		if len(parts) == 2 {
@@ -224,6 +242,7 @@ func ScanProjects(goDateFmt string, notesPaths ...string) ([]Task, error) {
 			DueTime:    dueTime,
 			Tags:       fm.Tags,
 			Status:     "open",
+			SortLast:   true,
 		})
 	}
 

--- a/go/testdata/fm-due-vault/active-status.md
+++ b/go/testdata/fm-due-vault/active-status.md
@@ -1,0 +1,11 @@
+---
+due: "2026-04-10"
+status: active
+tags:
+  - ongoing
+---
+# Active Project
+
+- [ ] Undated task in active project
+- [ ] Another undated in active
+- [x] Completed inline task (@[[2026-03-01]])

--- a/go/testdata/fm-due-vault/bare-date.md
+++ b/go/testdata/fm-due-vault/bare-date.md
@@ -1,0 +1,8 @@
+---
+due: 2026-04-15
+tags:
+  - work
+---
+# Bare Date (YAML auto-parses to time.Time)
+
+- [ ] Task with bare YAML date

--- a/go/testdata/fm-due-vault/basic-inherit.md
+++ b/go/testdata/fm-due-vault/basic-inherit.md
@@ -1,0 +1,10 @@
+---
+due: "2026-04-15"
+tags:
+  - work
+---
+# Basic Inherit
+
+- [ ] Undated task one
+- [ ] Undated task two
+- [ ] Dated task with inline (@[[2026-03-01]])

--- a/go/testdata/fm-due-vault/complete-status.md
+++ b/go/testdata/fm-due-vault/complete-status.md
@@ -1,0 +1,10 @@
+---
+due: "2026-03-20"
+status: complete
+tags:
+  - finished
+---
+# Complete Project
+
+- [ ] Undated task in complete file
+- [ ] Another undated in complete file

--- a/go/testdata/fm-due-vault/custom-key.md
+++ b/go/testdata/fm-due-vault/custom-key.md
@@ -1,0 +1,10 @@
+---
+deadline: "2026-06-01"
+tags:
+  - project
+---
+# Custom Key
+
+- [ ] Task using deadline key
+- [ ] Another deadline task
+- [ ] Inline overrides deadline (@[[2026-07-01]])

--- a/go/testdata/fm-due-vault/custom-status.md
+++ b/go/testdata/fm-due-vault/custom-status.md
@@ -1,0 +1,11 @@
+---
+deadline: "2026-06-15"
+state: archived
+tags:
+  - old
+---
+# Custom Status Key
+
+- [ ] Task in archived file
+- [ ] Another archived task
+- [ ] Inline dated in archived (@[[2026-08-01]])

--- a/go/testdata/fm-due-vault/done-file.md
+++ b/go/testdata/fm-due-vault/done-file.md
@@ -1,0 +1,11 @@
+---
+due: "2026-04-01"
+status: done
+tags:
+  - cleanup
+---
+# Done Project
+
+- [ ] Leftover undated task
+- [ ] Another leftover undated task
+- [ ] Inline dated task from done file (@[[2026-05-01]])

--- a/go/testdata/fm-due-vault/done-mixed.md
+++ b/go/testdata/fm-due-vault/done-mixed.md
@@ -1,0 +1,12 @@
+---
+due: "2026-03-15"
+status: done
+tags:
+  - finished
+---
+# Done file with mixed tasks
+
+- [ ] Undated in done file (should be filtered)
+- [ ] Another undated (should be filtered)
+- [ ] Inline dated survives done file (@[[2026-06-01]])
+- [ ] Second inline dated survives (@[[2026-06-15]])

--- a/go/testdata/fm-due-vault/due-with-time.md
+++ b/go/testdata/fm-due-vault/due-with-time.md
@@ -1,0 +1,9 @@
+---
+due: "2026-04-15 14:30"
+tags:
+  - meeting
+---
+# Due With Time
+
+- [ ] Undated task inheriting time
+- [ ] Inline has own time (@[[2026-04-15]] 09:00)

--- a/go/testdata/fm-due-vault/missing-required-tag.md
+++ b/go/testdata/fm-due-vault/missing-required-tag.md
@@ -1,0 +1,8 @@
+---
+due: "2026-05-20"
+tags:
+  - notes
+---
+# Missing Required Tags
+
+- [ ] Task in file missing required tag

--- a/go/testdata/fm-due-vault/mixed-inline-undated.md
+++ b/go/testdata/fm-due-vault/mixed-inline-undated.md
@@ -1,0 +1,12 @@
+---
+due: "2026-04-20"
+tags:
+  - mixed
+---
+# Mixed Inline and Undated
+
+- [ ] Undated inherits FM
+- [ ] Has inline date (@[[2026-03-10]])
+- [ ] Another undated inherits FM
+- [x] Done task
+- [ ] Third undated inherits FM

--- a/go/testdata/fm-due-vault/no-due.md
+++ b/go/testdata/fm-due-vault/no-due.md
@@ -1,0 +1,8 @@
+---
+tags:
+  - random
+---
+# No Due Date in FM
+
+- [ ] Undated task in no-due file
+- [ ] Another undated task here

--- a/go/testdata/fm-due-vault/no-frontmatter.md
+++ b/go/testdata/fm-due-vault/no-frontmatter.md
@@ -1,0 +1,4 @@
+# No Frontmatter
+
+- [ ] Undated task with no FM at all
+- [ ] Another task with no FM

--- a/go/testdata/fm-due-vault/project-sort.md
+++ b/go/testdata/fm-due-vault/project-sort.md
@@ -1,0 +1,7 @@
+---
+tags:
+  - project
+due: 2026-04-15
+---
+- [ ] First subtask
+- [ ] Second subtask

--- a/go/testdata/fm-due-vault/require-tags.md
+++ b/go/testdata/fm-due-vault/require-tags.md
@@ -1,0 +1,9 @@
+---
+due: "2026-05-20"
+tags:
+  - project
+  - important
+---
+# Has Required Tags
+
+- [ ] Task in file with required tags

--- a/go/vault_test.go
+++ b/go/vault_test.go
@@ -284,7 +284,7 @@ func TestVault_ProjectScanning(t *testing.T) {
 	ResetFrontmatterCache()
 	vault := vaultPath(t, "frontmatter-vault")
 
-	projectTasks, err := ScanProjects("2006-01-02", vault)
+	projectTasks, err := ScanProjects("2006-01-02", FrontmatterConfig{}, nil, vault)
 	if err != nil {
 		t.Fatalf("ScanProjects failed: %v", err)
 	}

--- a/lua/taskbuffer/config.lua
+++ b/lua/taskbuffer/config.lua
@@ -46,6 +46,16 @@
 ---@field taskfile TaskbufferTaskfileKeymaps
 ---@field markdown TaskbufferMarkdownKeymaps
 
+---@class TaskbufferFrontmatterStatus
+---@field key string YAML key for status field
+---@field done_values string[] values that indicate completion
+
+---@class TaskbufferFrontmatter
+---@field due_key string YAML key for the due date field
+---@field inherit_due boolean whether undated tasks inherit the file's frontmatter due date
+---@field require_tags string[] frontmatter tags required for inheritance (empty = all files)
+---@field status TaskbufferFrontmatterStatus status configuration
+
 ---@class TaskbufferInbox
 ---@field file string path to inbox markdown file
 ---@field header string|nil optional heading to insert below
@@ -62,6 +72,7 @@
 ---@field horizons table[]|nil horizon specs (label, after, undated, order)
 ---@field horizons_overlap string overlap strategy: "sorted"|"first_match"|"narrowest"
 ---@field week_start string first day of the week: "monday"|"sunday"|etc.
+---@field frontmatter TaskbufferFrontmatter frontmatter configuration
 
 ---@class TaskbufferConfigModule
 ---@field defaults TaskbufferConfig
@@ -92,6 +103,17 @@ M.defaults = {
     inbox = {
         file = "~/Documents/Notes/inbox.md",
         header = nil,
+    },
+
+    -- Frontmatter configuration
+    frontmatter = {
+        due_key = "due",
+        inherit_due = true,
+        require_tags = {},
+        status = {
+            key = "status",
+            done_values = { "done", "complete" },
+        },
     },
 
     -- Task syntax formats (passed to Go binary)
@@ -238,6 +260,16 @@ function M.config_json_arg()
     end
     if M.values.week_start ~= "monday" then
         cfg.week_start = M.values.week_start
+    end
+    local fm = M.values.frontmatter
+    if fm then
+        cfg.frontmatter = {
+            due_key = fm.due_key,
+            inherit_due = fm.inherit_due,
+            require_tags = fm.require_tags,
+            status_key = fm.status and fm.status.key or "status",
+            done_values = fm.status and fm.status.done_values or { "done", "complete" },
+        }
     end
     return vim.json.encode(cfg)
 end

--- a/lua/taskbuffer/keymaps.lua
+++ b/lua/taskbuffer/keymaps.lua
@@ -51,13 +51,16 @@ end
 
 --- Bulk-shift due dates for multiple taskfile lines.
 --- Groups edits by source file and processes from bottom-up to avoid line drift.
+--- Falls back to frontmatter due date for undated tasks (deduplicated per file).
 ---@param lines string[]
 ---@param days integer
 local function shift_task_dates_bulk(lines, days)
     local buffer = require("taskbuffer.buffer")
+    local cfg = get_config()
     local edits_by_file = {}
     local all_edits = {}
     local shifted = 0
+    local fm_shifted_files = {} -- track FM edits to deduplicate per file
     for _, line in ipairs(lines) do
         local filepath, linenumber = util.parse_taskfile_line(line)
         if filepath and linenumber then
@@ -73,6 +76,16 @@ local function shift_task_dates_bulk(lines, days)
                     table.insert(edits_by_file[filepath], edit)
                     all_edits[#all_edits + 1] = edit
                     shifted = shifted + 1
+                elseif cfg.frontmatter and cfg.frontmatter.inherit_due and not fm_shifted_files[filepath] then
+                    local due_key = cfg.frontmatter.due_key or "due"
+                    local fm_new_date, fm_line, old_fm_line, new_fm_line =
+                        util.shift_frontmatter_due(filepath, days, due_key)
+                    if fm_new_date then
+                        fm_shifted_files[filepath] = true
+                        all_edits[#all_edits + 1] =
+                            { filepath = filepath, linenumber = fm_line, old_line = old_fm_line, new_line = new_fm_line }
+                        shifted = shifted + 1
+                    end
                 end
             end
         end
@@ -81,7 +94,7 @@ local function shift_task_dates_bulk(lines, days)
         vim.notify("[taskbuffer] no dated tasks in selection", vim.log.levels.WARN)
         return
     end
-    -- Apply edits per file, sorted by line number descending to avoid drift
+    -- Apply inline edits per file, sorted by line number descending to avoid drift
     for _, edits in pairs(edits_by_file) do
         table.sort(edits, function(a, b)
             return a.linenumber > b.linenumber
@@ -90,6 +103,7 @@ local function shift_task_dates_bulk(lines, days)
             util.replace_line_in_file(edit.filepath, edit.linenumber, edit.new_line)
         end
     end
+    -- FM edits were already applied in shift_frontmatter_due
     local direction = days > 0 and "forward" or "back"
     local op = "shift " .. direction .. " " .. math.abs(days) .. " day(s)"
     require("taskbuffer.undo").push({ op = op, edits = all_edits, timestamp = os.time() })
@@ -114,6 +128,7 @@ end
 
 local function shift_task_date_in_taskfile(days)
     local buffer = require("taskbuffer.buffer")
+    local cfg = get_config()
     local line = vim.api.nvim_get_current_line()
     local filepath, linenumber = util.parse_taskfile_line(line)
     if not filepath or not linenumber then
@@ -126,29 +141,51 @@ local function shift_task_date_in_taskfile(days)
         return
     end
     local new_line, new_date = util.shift_date_in_string(source_line, days)
-    if not new_line then
-        vim.notify("[taskbuffer] no date found on this line", vim.log.levels.WARN)
+    if new_line then
+        util.replace_line_in_file(filepath, linenumber, new_line)
+        local direction = days > 0 and "forward" or "back"
+        local op = "shift " .. direction .. " " .. math.abs(days) .. " day(s)"
+        require("taskbuffer.undo").push({
+            op = op,
+            edits = { { filepath = filepath, linenumber = linenumber, old_line = source_line, new_line = new_line } },
+            timestamp = os.time(),
+        })
+        buffer.refresh_and_restore_cursor()
+        vim.notify("[taskbuffer] due: " .. new_date, vim.log.levels.INFO)
         return
     end
-    util.replace_line_in_file(filepath, linenumber, new_line)
-    local direction = days > 0 and "forward" or "back"
-    local op = "shift " .. direction .. " " .. math.abs(days) .. " day(s)"
-    require("taskbuffer.undo").push({
-        op = op,
-        edits = { { filepath = filepath, linenumber = linenumber, old_line = source_line, new_line = new_line } },
-        timestamp = os.time(),
-    })
-    buffer.refresh_and_restore_cursor()
-    vim.notify("[taskbuffer] due: " .. new_date, vim.log.levels.INFO)
+
+    -- Fallback: shift frontmatter due date
+    if cfg.frontmatter and cfg.frontmatter.inherit_due then
+        local due_key = cfg.frontmatter.due_key or "due"
+        local fm_new_date, fm_line, old_fm_line, new_fm_line = util.shift_frontmatter_due(filepath, days, due_key)
+        if fm_new_date then
+            local direction = days > 0 and "forward" or "back"
+            local op = "shift FM " .. direction .. " " .. math.abs(days) .. " day(s)"
+            require("taskbuffer.undo").push({
+                op = op,
+                edits = { { filepath = filepath, linenumber = fm_line, old_line = old_fm_line, new_line = new_fm_line } },
+                timestamp = os.time(),
+            })
+            buffer.refresh_and_restore_cursor()
+            vim.notify("[taskbuffer] FM due: " .. fm_new_date, vim.log.levels.INFO)
+            return
+        end
+    end
+
+    vim.notify("[taskbuffer] no date found on this line", vim.log.levels.WARN)
 end
 
 --- Bulk-set due dates to today for multiple taskfile lines.
+--- Falls back to frontmatter due date for undated tasks (deduplicated per file).
 ---@param lines string[]
 local function set_task_dates_today_bulk(lines)
     local buffer = require("taskbuffer.buffer")
+    local cfg = get_config()
     local edits_by_file = {}
     local all_edits = {}
     local updated = 0
+    local fm_set_files = {} -- track FM edits to deduplicate per file
     for _, line in ipairs(lines) do
         local filepath, linenumber = util.parse_taskfile_line(line)
         if filepath and linenumber then
@@ -164,6 +201,16 @@ local function set_task_dates_today_bulk(lines)
                     table.insert(edits_by_file[filepath], edit)
                     all_edits[#all_edits + 1] = edit
                     updated = updated + 1
+                elseif cfg.frontmatter and cfg.frontmatter.inherit_due and not fm_set_files[filepath] then
+                    local due_key = cfg.frontmatter.due_key or "due"
+                    local fm_new_date, fm_line, old_fm_line, new_fm_line =
+                        util.set_frontmatter_due_today(filepath, due_key)
+                    if fm_new_date then
+                        fm_set_files[filepath] = true
+                        all_edits[#all_edits + 1] =
+                            { filepath = filepath, linenumber = fm_line, old_line = old_fm_line, new_line = new_fm_line }
+                        updated = updated + 1
+                    end
                 end
             end
         end
@@ -180,6 +227,7 @@ local function set_task_dates_today_bulk(lines)
             util.replace_line_in_file(edit.filepath, edit.linenumber, edit.new_line)
         end
     end
+    -- FM edits were already applied in set_frontmatter_due_today
     require("taskbuffer.undo").push({ op = "set today", edits = all_edits, timestamp = os.time() })
     buffer.refresh_and_restore_cursor()
     vim.notify("[taskbuffer] set " .. updated .. " task(s) to today", vim.log.levels.INFO)
@@ -187,6 +235,7 @@ end
 
 local function set_date_today_in_taskfile()
     local buffer = require("taskbuffer.buffer")
+    local cfg = get_config()
     local line = vim.api.nvim_get_current_line()
     local filepath, linenumber = util.parse_taskfile_line(line)
     if not filepath or not linenumber then
@@ -199,40 +248,90 @@ local function set_date_today_in_taskfile()
         return
     end
     local new_line, new_date = util.set_date_today_in_string(source_line)
-    if not new_line then
-        vim.notify("[taskbuffer] no date found on this line", vim.log.levels.WARN)
+    if new_line then
+        util.replace_line_in_file(filepath, linenumber, new_line)
+        require("taskbuffer.undo").push({
+            op = "set today",
+            edits = { { filepath = filepath, linenumber = linenumber, old_line = source_line, new_line = new_line } },
+            timestamp = os.time(),
+        })
+        buffer.refresh_and_restore_cursor()
+        vim.notify("[taskbuffer] due: " .. new_date, vim.log.levels.INFO)
         return
     end
-    util.replace_line_in_file(filepath, linenumber, new_line)
-    require("taskbuffer.undo").push({
-        op = "set today",
-        edits = { { filepath = filepath, linenumber = linenumber, old_line = source_line, new_line = new_line } },
-        timestamp = os.time(),
-    })
-    buffer.refresh_and_restore_cursor()
-    vim.notify("[taskbuffer] due: " .. new_date, vim.log.levels.INFO)
+
+    -- Fallback: set frontmatter due date to today
+    if cfg.frontmatter and cfg.frontmatter.inherit_due then
+        local due_key = cfg.frontmatter.due_key or "due"
+        local fm_new_date, fm_line, old_fm_line, new_fm_line = util.set_frontmatter_due_today(filepath, due_key)
+        if fm_new_date then
+            require("taskbuffer.undo").push({
+                op = "set FM today",
+                edits = { { filepath = filepath, linenumber = fm_line, old_line = old_fm_line, new_line = new_fm_line } },
+                timestamp = os.time(),
+            })
+            buffer.refresh_and_restore_cursor()
+            vim.notify("[taskbuffer] FM due: " .. fm_new_date, vim.log.levels.INFO)
+            return
+        end
+    end
+
+    vim.notify("[taskbuffer] no date found on this line", vim.log.levels.WARN)
 end
 
 local function set_date_today_in_markdown()
+    local cfg = get_config()
     local line = vim.api.nvim_get_current_line()
     local new_line, new_date = util.set_date_today_in_string(line)
-    if not new_line then
-        vim.notify("[taskbuffer] no date found on this line", vim.log.levels.WARN)
+    if new_line then
+        vim.api.nvim_set_current_line(new_line)
+        vim.notify("[taskbuffer] due: " .. new_date, vim.log.levels.INFO)
         return
     end
-    vim.api.nvim_set_current_line(new_line)
-    vim.notify("[taskbuffer] due: " .. new_date, vim.log.levels.INFO)
+
+    -- Fallback: set frontmatter due date to today, jump cursor to FM line
+    if cfg.frontmatter and cfg.frontmatter.inherit_due then
+        local filepath = vim.api.nvim_buf_get_name(0)
+        local due_key = cfg.frontmatter.due_key or "due"
+        local fm_line_num, _, _ = util.find_frontmatter_due_line(filepath, due_key)
+        if fm_line_num then
+            local fm_new_date, _, _, new_fm_line = util.set_frontmatter_due_today(filepath, due_key)
+            if fm_new_date then
+                vim.cmd("edit!")
+                vim.api.nvim_win_set_cursor(0, { fm_line_num, 0 })
+                vim.notify("[taskbuffer] FM due: " .. fm_new_date, vim.log.levels.INFO)
+                return
+            end
+        end
+    end
+
+    vim.notify("[taskbuffer] no date found on this line", vim.log.levels.WARN)
 end
 
 local function shift_task_date_in_markdown(days)
+    local cfg = get_config()
     local line = vim.api.nvim_get_current_line()
     local new_line, new_date = util.shift_date_in_string(line, days)
-    if not new_line then
-        vim.notify("[taskbuffer] no date found on this line", vim.log.levels.WARN)
+    if new_line then
+        vim.api.nvim_set_current_line(new_line)
+        vim.notify("[taskbuffer] due: " .. new_date, vim.log.levels.INFO)
         return
     end
-    vim.api.nvim_set_current_line(new_line)
-    vim.notify("[taskbuffer] due: " .. new_date, vim.log.levels.INFO)
+
+    -- Fallback: shift frontmatter due date, jump cursor to FM line
+    if cfg.frontmatter and cfg.frontmatter.inherit_due then
+        local filepath = vim.api.nvim_buf_get_name(0)
+        local due_key = cfg.frontmatter.due_key or "due"
+        local fm_new_date, fm_line_num = util.shift_frontmatter_due(filepath, days, due_key)
+        if fm_new_date then
+            vim.cmd("edit!")
+            vim.api.nvim_win_set_cursor(0, { fm_line_num, 0 })
+            vim.notify("[taskbuffer] FM due: " .. fm_new_date, vim.log.levels.INFO)
+            return
+        end
+    end
+
+    vim.notify("[taskbuffer] no date found on this line", vim.log.levels.WARN)
 end
 
 function M.setup_keymaps()

--- a/lua/taskbuffer/util.lua
+++ b/lua/taskbuffer/util.lua
@@ -279,6 +279,131 @@ function M.get_visual_lines()
     return vim.api.nvim_buf_get_lines(0, s_line - 1, e_line, false)
 end
 
+--- Find the frontmatter due date line in a file.
+--- Scans for `<due_key>:` between `---` delimiters.
+---@param path string
+---@param due_key string
+---@return integer|nil line_number
+---@return string|nil current_value (the date portion)
+---@return boolean is_quoted
+function M.find_frontmatter_due_line(path, due_key)
+    local in_fm = false
+    local i = 0
+    for line in io.lines(path) do
+        i = i + 1
+        if i == 1 then
+            if line:match("^%-%-%-$") then
+                in_fm = true
+            else
+                return nil, nil, false
+            end
+        elseif in_fm then
+            if line:match("^%-%-%-$") then
+                return nil, nil, false
+            end
+            local key, value = line:match("^(" .. vim.pesc(due_key) .. "):%s*(.*)$")
+            if key then
+                local quoted = false
+                local date_val = value
+                -- Strip quotes if present
+                local q = value:match('^"(.*)"$') or value:match("^'(.*)'$")
+                if q then
+                    quoted = true
+                    date_val = q
+                end
+                return i, date_val, quoted
+            end
+        end
+    end
+    return nil, nil, false
+end
+
+--- Shift the frontmatter due date in a file by a number of days.
+---@param path string
+---@param days integer
+---@param due_key string
+---@return string|nil new_date
+---@return integer|nil line_number
+---@return string|nil old_line
+---@return string|nil new_line
+function M.shift_frontmatter_due(path, days, due_key)
+    local line_num, date_val, is_quoted = M.find_frontmatter_due_line(path, due_key)
+    if not line_num or not date_val or date_val == "" then
+        return nil, nil, nil, nil
+    end
+
+    -- Parse date (just the date portion, ignore time)
+    local date_part = date_val:match("^(%S+)")
+    if not date_part then
+        return nil, nil, nil, nil
+    end
+
+    local y, m, d = parse_date_components(date_part)
+    if not y then
+        return nil, nil, nil, nil
+    end
+
+    local cfg = require("taskbuffer.config").values.formats
+    local date_fmt = cfg.date or "%Y-%m-%d"
+    local t = os.time({ year = y, month = m, day = d })
+    local new_t = t + days * 86400
+    local new_date = os.date(date_fmt, new_t)
+
+    -- Reconstruct time portion if present
+    local time_part = date_val:match("^%S+%s+(.+)$")
+    local new_val = new_date
+    if time_part then
+        new_val = new_date .. " " .. time_part
+    end
+
+    local old_full_line = M.read_line_from_file(path, line_num)
+    local new_full_line
+    if is_quoted then
+        new_full_line = due_key .. ': "' .. new_val .. '"'
+    else
+        new_full_line = due_key .. ": " .. new_val
+    end
+
+    M.replace_line_in_file(path, line_num, new_full_line)
+    return new_date, line_num, old_full_line, new_full_line
+end
+
+--- Set the frontmatter due date to today.
+---@param path string
+---@param due_key string
+---@return string|nil new_date
+---@return integer|nil line_number
+---@return string|nil old_line
+---@return string|nil new_line
+function M.set_frontmatter_due_today(path, due_key)
+    local line_num, date_val, is_quoted = M.find_frontmatter_due_line(path, due_key)
+    if not line_num or not date_val or date_val == "" then
+        return nil, nil, nil, nil
+    end
+
+    local cfg = require("taskbuffer.config").values.formats
+    local date_fmt = cfg.date or "%Y-%m-%d"
+    local today = os.date(date_fmt)
+
+    -- Preserve time portion if present
+    local time_part = date_val:match("^%S+%s+(.+)$")
+    local new_val = today
+    if time_part then
+        new_val = today .. " " .. time_part
+    end
+
+    local old_full_line = M.read_line_from_file(path, line_num)
+    local new_full_line
+    if is_quoted then
+        new_full_line = due_key .. ': "' .. new_val .. '"'
+    else
+        new_full_line = due_key .. ": " .. new_val
+    end
+
+    M.replace_line_in_file(path, line_num, new_full_line)
+    return today, line_num, old_full_line, new_full_line
+end
+
 --- Parse taskfile lines into quickfix entries.
 ---@param lines string[]
 ---@return table[] qf_list


### PR DESCRIPTION
## Summary
- Undated tasks now inherit due dates from YAML frontmatter (`due:` key), with configurable key, tag requirements, and status-based filtering
- Project tasks (files tagged `project` with a frontmatter due date) appear as synthetic tasks sorted after regular tasks via `SortLast`
- Strict date validation mode for catching malformed dates
- Full documentation sync: README, vim help, and CLAUDE.md updated with frontmatter config, missing keymaps (`set_date_today`, `undo`/`redo`, `quickfix`), health check, and corrected architecture file lists

## Test plan
- [x] Go unit tests for frontmatter due inheritance (`fm_due_e2e_test.go`)
- [x] Go unit tests for strict date validation (`date_validation_test.go`)
- [x] Existing test suite passes (`go test ./...`)
- [ ] Manual verification: undated tasks in files with `due:` frontmatter show under correct horizon
- [ ] Manual verification: `:checkhealth taskbuffer` runs cleanly

Generated with [Claude Code](https://claude.com/claude-code)