### PR TITLE
fix: guard file readers against deleted/renamed source notes

### DIFF
--- a/lua/taskbuffer/util.lua
+++ b/lua/taskbuffer/util.lua
@@ -1,5 +1,15 @@
 local M = {}
 
+--- True when `path` exists on disk. Guards the io.lines() callers below:
+--- io.lines() raises (rather than returning nil) when the path is missing,
+--- which crashes callers when a source note has been deleted or renamed since
+--- the taskfile was generated.
+---@param path string
+---@return boolean
+local function file_exists(path)
+    return (vim.uv or vim.loop).fs_stat(path) ~= nil
+end
+
 --- Parse a taskfile line into filepath and line number.
 ---@param line string
 ---@return string filepath
@@ -16,6 +26,9 @@ end
 ---@param target integer
 ---@return string|nil
 function M.read_line_from_file(path, target)
+    if not file_exists(path) then
+        return nil
+    end
     local i = 0
     for l in io.lines(path) do
         i = i + 1
@@ -31,6 +44,10 @@ end
 ---@param target_line integer
 ---@param new_content string
 function M.replace_line_in_file(path, target_line, new_content)
+    if not file_exists(path) then
+        vim.notify("[taskbuffer] source file not found: " .. path, vim.log.levels.WARN)
+        return
+    end
     local lines = {}
     local i = 0
     for line in io.lines(path) do
@@ -56,6 +73,10 @@ end
 ---@param target_line integer
 ---@param suffix string
 function M.append_to_line(path, target_line, suffix)
+    if not file_exists(path) then
+        vim.notify("[taskbuffer] source file not found: " .. path, vim.log.levels.WARN)
+        return
+    end
     local lines = {}
     local i = 0
     for line in io.lines(path) do
@@ -279,6 +300,9 @@ end
 ---@return string|nil current_value (the date portion)
 ---@return boolean is_quoted
 function M.find_frontmatter_due_line(path, due_key)
+    if not file_exists(path) then
+        return nil, nil, false
+    end
     local in_fm = false
     local i = 0
     for line in io.lines(path) do

--- a/tests/unit/util_spec.lua
+++ b/tests/unit/util_spec.lua
@@ -1,0 +1,84 @@
+-- Regression coverage for the file-reading helpers in util.lua.
+--
+-- A taskfile line points back at a source note (`path:line:...`). That note can
+-- be deleted or renamed after the taskfile was generated; when it is, the
+-- helpers must degrade gracefully instead of letting io.lines() raise. The
+-- crash this guards against: shifting a task date on a line whose source note
+-- no longer exists.
+--
+-- Fixtures are written under vim.fn.tempname() (OS tempdir), never the worktree.
+
+local util = require("taskbuffer.util")
+
+-- Write content bytes to a fresh temp .md file, return its path.
+local function temp_md(content)
+    local path = vim.fn.tempname() .. ".md"
+    local f = assert(io.open(path, "wb"))
+    f:write(content)
+    f:close()
+    return path
+end
+
+-- A temp path that does NOT exist on disk.
+local function missing_path()
+    return vim.fn.tempname() .. ".md"
+end
+
+local function read_raw(path)
+    local f = assert(io.open(path, "rb"))
+    local data = f:read("*a")
+    f:close()
+    return data
+end
+
+describe("util.read_line_from_file", function()
+    it("returns the requested line when the file exists", function()
+        local path = temp_md("line one\nline two\nline three\n")
+        assert.are.equal("line two", util.read_line_from_file(path, 2))
+    end)
+
+    it("returns nil for an out-of-range line number", function()
+        local path = temp_md("only one line\n")
+        assert.is_nil(util.read_line_from_file(path, 5))
+    end)
+
+    it("returns nil (no error) when the source file does not exist", function()
+        local path = missing_path()
+        assert.has_no.errors(function()
+            assert.is_nil(util.read_line_from_file(path, 1))
+        end)
+    end)
+end)
+
+describe("util.replace_line_in_file", function()
+    it("does not error when the source file does not exist", function()
+        local path = missing_path()
+        assert.has_no.errors(function()
+            util.replace_line_in_file(path, 1, "new content")
+        end)
+    end)
+end)
+
+describe("util.append_to_line", function()
+    it("does not error when the source file does not exist", function()
+        local path = missing_path()
+        assert.has_no.errors(function()
+            util.append_to_line(path, 1, " ::start [[2026-02-17]] 15:00")
+        end)
+    end)
+
+    it("still appends to an existing file", function()
+        local path = temp_md("alpha\nbeta\n")
+        util.append_to_line(path, 1, " X")
+        assert.are.equal("alpha X\nbeta\n", read_raw(path))
+    end)
+end)
+
+describe("util.find_frontmatter_due_line", function()
+    it("returns nil when the source file does not exist", function()
+        local path = missing_path()
+        assert.has_no.errors(function()
+            assert.is_nil(util.find_frontmatter_due_line(path, "due"))
+        end)
+    end)
+end)


### PR DESCRIPTION
## Problem

A taskfile line points back at its source note (`path:line:...`). When that note is **deleted or renamed** after the taskfile was generated, pressing the date-shift key (or any verb routing through the file helpers) crashed:

```
E5108: Error executing lua: util.lua:20: bad argument #1 to 'lines'
(/home/tjmisko/Notes/daily/2026-02-09.md: No such file or directory)
```

`util.read_line_from_file` called `io.lines(path)`, which **raises** on a missing file rather than returning `nil`. The caller (`keymaps.lua:142`) already handles a `nil` return gracefully ("could not read source line"), but `io.lines` threw before it got the chance. The same latent bug existed in `replace_line_in_file`, `append_to_line`, and `find_frontmatter_due_line`.

## Fix

Add a `file_exists()` guard (via `vim.uv.fs_stat`) in front of all four `io.lines()` sites in `util.lua`:
- `read_line_from_file` / `find_frontmatter_due_line` → return `nil` (callers already handle it)
- `replace_line_in_file` / `append_to_line` → notify `source file not found` and skip the write

## Tests

New `tests/unit/util_spec.lua` (7 tests) covering the missing-file regression plus the happy path. Full suite green (14 files, 0 failures), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)